### PR TITLE
Add a generic `GpioPin` type for downgrading

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -157,9 +157,9 @@ where
 
         let sys_config = i2c_config_t {
             mode: i2c_mode_t_I2C_MODE_MASTER,
-            sda_io_num: SDA::pin() as i32,
+            sda_io_num: pins.sda.pin(),
             sda_pullup_en: config.sda_pullup_enabled,
-            scl_io_num: SCL::pin() as i32,
+            scl_io_num: pins.scl.pin(),
             scl_pullup_en: config.scl_pullup_enabled,
             __bindgen_anon_1: i2c_config_t__bindgen_ty_1 {
                 master: i2c_config_t__bindgen_ty_1__bindgen_ty_1 {
@@ -328,9 +328,9 @@ where
     ) -> Result<Self, EspError> {
         let sys_config = i2c_config_t {
             mode: i2c_mode_t_I2C_MODE_SLAVE,
-            sda_io_num: SDA::pin() as i32,
+            sda_io_num: pins.sda.pin(),
             sda_pullup_en: config.sda_pullup_enabled,
-            scl_io_num: SCL::pin() as i32,
+            scl_io_num: pins.scl.pin(),
             scl_pullup_en: config.scl_pullup_enabled,
             __bindgen_anon_1: i2c_config_t__bindgen_ty_1 {
                 slave: i2c_config_t__bindgen_ty_1__bindgen_ty_2 {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -329,10 +329,10 @@ impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin>
         esp!(unsafe {
             uart_set_pin(
                 UART::port(),
-                TX::pin(),
-                RX::pin(),
-                if pins.rts.is_some() { RTS::pin() } else { -1 },
-                if pins.cts.is_some() { CTS::pin() } else { -1 },
+                pins.tx.pin(),
+                pins.rx.pin(),
+                pins.rts.as_ref().map_or(-1, |p| p.pin()),
+                pins.cts.as_ref().map_or(-1, |p| p.pin()),
             )
         })?;
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -204,10 +204,10 @@ impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: O
         #[cfg(not(any(esp_idf_version = "4.4", esp_idf_version_major = "5")))]
         let bus_config = spi_bus_config_t {
             flags: SPICOMMON_BUSFLAG_MASTER,
-            sclk_io_num: SCLK::pin(),
+            sclk_io_num: pins.sclk.pin(),
 
-            mosi_io_num: SDO::pin(),
-            miso_io_num: if pins.sdi.is_some() { SDI::pin() } else { -1 },
+            mosi_io_num: pins.sdo.pin(),
+            miso_io_num: pins.sdi.as_ref().map_or(-1, |p| p.pin()),
             quadwp_io_num: -1,
             quadhd_io_num: -1,
 
@@ -220,7 +220,7 @@ impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: O
         })?;
 
         let device_config = spi_device_interface_config_t {
-            spics_io_num: if pins.cs.is_some() { CS::pin() } else { -1 },
+            spics_io_num: pins.cs.as_ref().map_or(-1, |p| p.pin()),
             clock_speed_hz: config.baudrate.0 as i32,
             mode: (if config.data_mode.polarity == Polarity::IdleHigh {
                 2


### PR DESCRIPTION
The new GpioPin type is generic over its direction (Input or Output) and captures the pin number in a member variable.
It is useful for situations where concrete types cause errors, e.g. collecting multiple pins in an array. At the same time the new type is conform with the current API for peripherals.

This is an implementation of #15.