### PR TITLE
Apply fix to read output state of a GPIO successfully

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -238,7 +238,10 @@ macro_rules! impl_hal_output_pin {
 
         impl embedded_hal::digital::v2::StatefulOutputPin for $pxi<$mode> {
             fn is_set_high(&self) -> Result<bool, Self::Error> {
-                Ok(unsafe { gpio_get_level($pxi::<$mode>::runtime_pin()) } != 0)
+                Ok(unsafe {
+                    (*(GPIO_OUT_REG as *const u32) >> $pxi::<$mode>::runtime_pin() as u32) & 0x01
+                        != 0
+                })
             }
 
             fn is_set_low(&self) -> Result<bool, Self::Error> {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -238,10 +238,20 @@ macro_rules! impl_hal_output_pin {
 
         impl embedded_hal::digital::v2::StatefulOutputPin for $pxi<$mode> {
             fn is_set_high(&self) -> Result<bool, Self::Error> {
-                Ok(unsafe {
-                    (*(GPIO_OUT_REG as *const u32) >> $pxi::<$mode>::runtime_pin() as u32) & 0x01
-                        != 0
-                })
+                let pin = $pxi::<$mode>::runtime_pin() as u32;
+
+                #[cfg(esp32c3)]
+                let is_set_high = unsafe { (*(GPIO_OUT_REG as *const u32) >> pin) & 0x01 != 0 };
+                #[cfg(not(esp32c3))]
+                let is_set_high = if pin <= 31 {
+                    // GPIO0 - GPIO31
+                    unsafe { (*(GPIO_OUT_REG as *const u32) >> pin) & 0x01 != 0 }
+                } else {
+                    // GPIO32+
+                    unsafe { (*(GPIO_OUT1_REG as *const u32) >> (pin - 32)) & 0x01 != 0 }
+                };
+
+                Ok(is_set_high)
             }
 
             fn is_set_low(&self) -> Result<bool, Self::Error> {


### PR DESCRIPTION
Since we are not reliably able to read the output state with the existing implementation, I've just dropped down a level and read the `GPIO_OUT_REG` register directly. This is a bit ugly, but the `StatefulOutputPin` and `ToggleableOutputPin` trait implementations are now working as expected. If there is a function in `esp-idf-sys` which will do this please let me know, but I did not see one.

This has been tested on the ESP32, ESP32-C3, and ESP32-S2. Just to note, I did try testing the ESP32-S3 as well but encountered an error originating from `esp-idf-sys` saying that PIO did not have a matching definition for the ESP32-S3.

Fixes #17
