### PR TITLE
Apply fixes for new lint added in most recent nightly version of clippy

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -27,21 +27,25 @@ pub mod config {
     }
 
     impl MasterConfig {
+        #[must_use]
         pub fn baudrate(mut self, baudrate: Hertz) -> Self {
             self.baudrate = baudrate;
             self
         }
 
+        #[must_use]
         pub fn timeout(mut self, timeout: Option<Duration>) -> Self {
             self.timeout = timeout;
             self
         }
 
+        #[must_use]
         pub fn sda_enable_pullup(mut self, enable: bool) -> Self {
             self.sda_pullup_enabled = enable;
             self
         }
 
+        #[must_use]
         pub fn scl_enable_pullup(mut self, enable: bool) -> Self {
             self.scl_pullup_enabled = enable;
             self
@@ -70,26 +74,31 @@ pub mod config {
     }
 
     impl SlaveConfig {
+        #[must_use]
         pub fn timeout(mut self, timeout: Option<Duration>) -> Self {
             self.timeout = timeout;
             self
         }
 
+        #[must_use]
         pub fn sda_enable_pullup(mut self, enable: bool) -> Self {
             self.sda_pullup_enabled = enable;
             self
         }
 
+        #[must_use]
         pub fn scl_enable_pullup(mut self, enable: bool) -> Self {
             self.scl_pullup_enabled = enable;
             self
         }
 
+        #[must_use]
         pub fn rx_buffer_length(mut self, len: usize) -> Self {
             self.rx_buf_len = len;
             self
         }
 
+        #[must_use]
         pub fn tx_buffer_length(mut self, len: usize) -> Self {
             self.tx_buf_len = len;
             self

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -211,36 +211,43 @@ pub mod config {
     }
 
     impl Config {
+        #[must_use]
         pub fn baudrate(mut self, baudrate: Hertz) -> Self {
             self.baudrate = baudrate;
             self
         }
 
+        #[must_use]
         pub fn parity_none(mut self) -> Self {
             self.parity = Parity::ParityNone;
             self
         }
 
+        #[must_use]
         pub fn parity_even(mut self) -> Self {
             self.parity = Parity::ParityEven;
             self
         }
 
+        #[must_use]
         pub fn parity_odd(mut self) -> Self {
             self.parity = Parity::ParityOdd;
             self
         }
 
+        #[must_use]
         pub fn data_bits(mut self, data_bits: DataBits) -> Self {
             self.data_bits = data_bits;
             self
         }
 
+        #[must_use]
         pub fn stop_bits(mut self, stop_bits: StopBits) -> Self {
             self.stop_bits = stop_bits;
             self
         }
 
+        #[must_use]
         pub fn flow_control(mut self, flow_control: FlowControl) -> Self {
             self.flow_control = flow_control;
             self

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -69,16 +69,19 @@ pub mod config {
     }
 
     impl Config {
+        #[must_use]
         pub fn baudrate(mut self, baudrate: Hertz) -> Self {
             self.baudrate = baudrate;
             self
         }
 
+        #[must_use]
         pub fn data_mode(mut self, data_mode: embedded_hal::spi::Mode) -> Self {
             self.data_mode = data_mode;
             self
         }
 
+        #[must_use]
         pub fn bit_order(mut self, bit_order: BitOrder) -> Self {
             self.bit_order = bit_order;
             self


### PR DESCRIPTION
After updating Rust nightly (to `rustc 1.59.0-nightly (7abab1efb 2021-12-17)`) a new lint rule was added to clippy, which caused some lint errors. This fixes them.