### PR TITLE
Upgrade to embedded-hal 1.0.0-alpha.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ulp = []
 [dependencies]
 nb = "0.1.2"
 mutex-trait = "0.2"
-embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-hal = "=1.0.0-alpha.6"
 esp-idf-sys = { version = "0.28.1", optional = true, default-features = false, features = ["pio"] }
 
 [build-dependencies]

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -262,23 +262,23 @@ impl<ADC: Adc> PoweredAdc<ADC> {
 }
 
 #[cfg(not(feature = "ulp"))]
-impl<ADC, AN, PIN> embedded_hal::adc::OneShot<AN, u16, PIN> for PoweredAdc<ADC>
+impl<ADC, AN, PIN> embedded_hal::adc::nb::OneShot<AN, u16, PIN> for PoweredAdc<ADC>
 where
     ADC: Adc,
     AN: Analog<ADC>,
-    PIN: embedded_hal::adc::Channel<AN, ID = u8>,
+    PIN: embedded_hal::adc::nb::Channel<AN, ID = u8>,
 {
     type Error = EspError;
 
-    fn read(&mut self, _pin: &mut PIN) -> nb::Result<u16, Self::Error> {
+    fn read(&mut self, pin: &mut PIN) -> nb::Result<u16, Self::Error> {
         let mut measurement = 0_i32;
 
         if ADC::unit() == adc_unit_t_ADC_UNIT_1 {
-            measurement = unsafe { adc1_get_raw(PIN::channel() as adc_channel_t) };
+            measurement = unsafe { adc1_get_raw(pin.channel() as adc_channel_t) };
         } else {
             let res = unsafe {
                 adc2_get_raw(
-                    PIN::channel() as adc_channel_t,
+                    pin.channel() as adc_channel_t,
                     self.resolution.into(),
                     &mut measurement as *mut _,
                 )
@@ -296,7 +296,7 @@ where
 }
 
 #[cfg(all(esp32, not(feature = "ulp")))]
-impl embedded_hal::adc::OneShot<ADC1, u16, hall::HallSensor> for PoweredAdc<ADC1> {
+impl embedded_hal::adc::nb::OneShot<ADC1, u16, hall::HallSensor> for PoweredAdc<ADC1> {
     type Error = EspError;
 
     fn read(&mut self, _hall_sensor: &mut hall::HallSensor) -> nb::Result<u16, Self::Error> {

--- a/src/hall.rs
+++ b/src/hall.rs
@@ -15,10 +15,10 @@ impl HallSensor {
 
 unsafe impl Send for HallSensor {}
 
-impl embedded_hal::adc::Channel<adc::ADC1> for HallSensor {
+impl embedded_hal::adc::nb::Channel<adc::ADC1> for HallSensor {
     type ID = ();
 
-    fn channel() -> Self::ID {
+    fn channel(&self) -> Self::ID {
         ()
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -215,118 +215,137 @@ where
     }
 }
 
-impl<I2C, SDA, SCL> embedded_hal::blocking::i2c::Read for Master<I2C, SDA, SCL>
+impl<I2C, SDA, SCL> embedded_hal::i2c::blocking::Read for Master<I2C, SDA, SCL>
 where
     I2C: I2c,
     SDA: OutputPin + InputPin,
     SCL: OutputPin,
 {
-    type Error = EspError;
+    type Error = embedded_hal::i2c::ErrorKind;
 
     fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        let command_link = CommandLink::new()?;
+        let command_link = CommandLink::new().map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
         unsafe {
-            esp!(i2c_master_start(command_link.0))?;
+            esp!(i2c_master_start(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_READ as u8),
                 true
-            ))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_read(
                 command_link.0,
                 buffer.as_ptr() as *const u8 as *mut u8,
                 buffer.len() as u32,
                 i2c_ack_type_t_I2C_MASTER_LAST_NACK
-            ))?;
-            esp!(i2c_master_stop(command_link.0))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_stop(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
             esp_result!(
                 i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout),
                 ()
             )
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)
         }
     }
 }
 
-impl<I2C, SDA, SCL> embedded_hal::blocking::i2c::Write for Master<I2C, SDA, SCL>
+impl<I2C, SDA, SCL> embedded_hal::i2c::blocking::Write for Master<I2C, SDA, SCL>
 where
     I2C: I2c,
     SDA: OutputPin + InputPin,
     SCL: OutputPin,
 {
-    type Error = EspError;
+    type Error = embedded_hal::i2c::ErrorKind;
 
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
         unsafe {
-            let command_link = CommandLink::new()?;
+            let command_link =
+                CommandLink::new().map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
-            esp!(i2c_master_start(command_link.0))?;
+            esp!(i2c_master_start(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_WRITE as u8),
                 true
-            ))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_write(
                 command_link.0,
                 bytes.as_ptr() as *const u8 as *mut u8,
                 bytes.len() as u32,
                 true
-            ))?;
-            esp!(i2c_master_stop(command_link.0))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_stop(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
             esp_result!(
                 i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout),
                 ()
             )
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)
         }
     }
 }
 
-impl<I2C, SDA, SCL> embedded_hal::blocking::i2c::WriteRead for Master<I2C, SDA, SCL>
+impl<I2C, SDA, SCL> embedded_hal::i2c::blocking::WriteRead for Master<I2C, SDA, SCL>
 where
     I2C: I2c,
     SDA: OutputPin + InputPin,
     SCL: OutputPin,
 {
-    type Error = EspError;
+    type Error = embedded_hal::i2c::ErrorKind;
 
     fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
-        let command_link = CommandLink::new()?;
+        let command_link = CommandLink::new().map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
         unsafe {
-            esp!(i2c_master_start(command_link.0))?;
+            esp!(i2c_master_start(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_WRITE as u8),
                 true
-            ))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_write(
                 command_link.0,
                 bytes.as_ptr() as *const u8 as *mut u8,
                 bytes.len() as u32,
                 true
-            ))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
-            esp!(i2c_master_start(command_link.0))?;
+            esp!(i2c_master_start(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_READ as u8),
                 true
-            ))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_read(
                 command_link.0,
                 buffer.as_ptr() as *const u8 as *mut u8,
                 buffer.len() as u32,
                 i2c_ack_type_t_I2C_MASTER_LAST_NACK
-            ))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
-            esp!(i2c_master_stop(command_link.0))?;
+            esp!(i2c_master_stop(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
             esp_result!(
                 i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout),
                 ()
             )
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)
         }
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,6 +1,11 @@
 use crate::{delay::*, gpio::*, units::*};
-
 use esp_idf_sys::*;
+
+crate::embedded_hal_error!(
+    I2cError,
+    embedded_hal::i2c::Error,
+    embedded_hal::i2c::ErrorKind
+);
 
 pub struct MasterPins<SDA: OutputPin + InputPin, SCL: OutputPin> {
     pub sda: SDA,
@@ -221,35 +226,33 @@ where
     SDA: OutputPin + InputPin,
     SCL: OutputPin,
 {
-    type Error = embedded_hal::i2c::ErrorKind;
+    type Error = I2cError;
 
     fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        let command_link = CommandLink::new().map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+        let command_link = CommandLink::new().map_err(I2cError::other)?;
 
         unsafe {
-            esp!(i2c_master_start(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_start(command_link.0)).map_err(I2cError::other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_READ as u8),
                 true
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
             esp!(i2c_master_read(
                 command_link.0,
                 buffer.as_ptr() as *const u8 as *mut u8,
                 buffer.len() as u32,
                 i2c_ack_type_t_I2C_MASTER_LAST_NACK
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
-            esp!(i2c_master_stop(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
+            esp!(i2c_master_stop(command_link.0)).map_err(I2cError::other)?;
 
             esp_result!(
                 i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout),
                 ()
             )
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)
+            .map_err(I2cError::other)
         }
     }
 }
@@ -260,36 +263,33 @@ where
     SDA: OutputPin + InputPin,
     SCL: OutputPin,
 {
-    type Error = embedded_hal::i2c::ErrorKind;
+    type Error = I2cError;
 
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
         unsafe {
-            let command_link =
-                CommandLink::new().map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            let command_link = CommandLink::new().map_err(I2cError::other)?;
 
-            esp!(i2c_master_start(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_start(command_link.0)).map_err(I2cError::other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_WRITE as u8),
                 true
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
             esp!(i2c_master_write(
                 command_link.0,
                 bytes.as_ptr() as *const u8 as *mut u8,
                 bytes.len() as u32,
                 true
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
-            esp!(i2c_master_stop(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
+            esp!(i2c_master_stop(command_link.0)).map_err(I2cError::other)?;
 
             esp_result!(
                 i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout),
                 ()
             )
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)
+            .map_err(I2cError::other)
         }
     }
 }
@@ -300,52 +300,49 @@ where
     SDA: OutputPin + InputPin,
     SCL: OutputPin,
 {
-    type Error = embedded_hal::i2c::ErrorKind;
+    type Error = I2cError;
 
     fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
-        let command_link = CommandLink::new().map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+        let command_link = CommandLink::new().map_err(I2cError::other)?;
 
         unsafe {
-            esp!(i2c_master_start(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_start(command_link.0)).map_err(I2cError::other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_WRITE as u8),
                 true
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
             esp!(i2c_master_write(
                 command_link.0,
                 bytes.as_ptr() as *const u8 as *mut u8,
                 bytes.len() as u32,
                 true
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
 
-            esp!(i2c_master_start(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_start(command_link.0)).map_err(I2cError::other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_READ as u8),
                 true
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
             esp!(i2c_master_read(
                 command_link.0,
                 buffer.as_ptr() as *const u8 as *mut u8,
                 buffer.len() as u32,
                 i2c_ack_type_t_I2C_MASTER_LAST_NACK
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
 
-            esp!(i2c_master_stop(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_stop(command_link.0)).map_err(I2cError::other)?;
 
             esp_result!(
                 i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout),
                 ()
             )
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)
+            .map_err(I2cError::other)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,3 +27,59 @@ pub mod units;
 
 #[cfg(feature = "ulp")]
 pub use crate::ulp::delay;
+
+// This is used to create `embedded_hal` compatible error structs
+// that preserve original `EspError`.
+//
+// Example:
+// embedded_hal_error!(I2cError, embedded_hal::i2c::Error, embedded_hal::i2c::ErrorKind)
+macro_rules! embedded_hal_error {
+    ($error:ident, $errortrait:ty, $kind:ty) => {
+        #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+        pub struct $error {
+            kind: $kind,
+            cause: esp_idf_sys::EspError,
+        }
+
+        impl $error {
+            pub fn new(kind: $kind, cause: esp_idf_sys::EspError) -> Self {
+                Self { kind, cause }
+            }
+            pub fn other(cause: esp_idf_sys::EspError) -> Self {
+                Self::new(<$kind>::Other, cause)
+            }
+            pub fn cause(&self) -> esp_idf_sys::EspError {
+                self.cause
+            }
+        }
+
+        impl From<esp_idf_sys::EspError> for $error {
+            fn from(e: esp_idf_sys::EspError) -> Self {
+                Self::other(e)
+            }
+        }
+
+        impl $errortrait for $error {
+            fn kind(&self) -> $kind {
+                self.kind
+            }
+        }
+
+        impl core::fmt::Display for $error {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                write!(
+                    f,
+                    "{} {{ kind: {}, cause: {} }}",
+                    stringify!($error),
+                    self.kind,
+                    self.cause()
+                )
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl std::error::Error for $error {}
+    };
+}
+
+pub(crate) use embedded_hal_error;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,9 +9,8 @@
 pub use crate::peripherals::*;
 pub use crate::units::*;
 
-pub use embedded_hal::digital::v2::InputPin as _;
-pub use embedded_hal::digital::v2::OutputPin as _;
-pub use embedded_hal::digital::v2::StatefulOutputPin as _;
-pub use embedded_hal::digital::v2::ToggleableOutputPin as _;
-pub use embedded_hal::prelude::*;
-pub use embedded_hal::timer::{Cancel, CountDown, Periodic};
+pub use embedded_hal::digital::blocking::InputPin as _;
+pub use embedded_hal::digital::blocking::OutputPin as _;
+pub use embedded_hal::digital::blocking::StatefulOutputPin as _;
+pub use embedded_hal::digital::blocking::ToggleableOutputPin as _;
+pub use embedded_hal::timer::nb::{Cancel, CountDown};

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -44,8 +44,6 @@ use core::ptr;
 
 use embedded_hal::serial;
 
-//use crate::prelude::*;
-
 use crate::gpio::*;
 use crate::units::*;
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -500,20 +500,20 @@ impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin>
     // }
 }
 
-impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> serial::Read<u8>
+impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> serial::nb::Read<u8>
     for Serial<UART, TX, RX, CTS, RTS>
 {
-    type Error = EspError;
+    type Error = serial::ErrorKind;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self.rx.read()
     }
 }
 
-impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> serial::Write<u8>
+impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> serial::nb::Write<u8>
     for Serial<UART, TX, RX, CTS, RTS>
 {
-    type Error = EspError;
+    type Error = serial::ErrorKind;
 
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
         self.tx.flush()
@@ -528,7 +528,7 @@ impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> cor
     for Serial<UART, TX, RX, CTS, RTS>
 {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        use embedded_hal::serial::Write;
+        use embedded_hal::serial::nb::Write;
         s.as_bytes()
             .iter()
             .try_for_each(|c| nb::block!(self.write(*c)))
@@ -552,8 +552,8 @@ impl<UART: Uart> Rx<UART> {
     // }
 }
 
-impl<UART: Uart> serial::Read<u8> for Rx<UART> {
-    type Error = EspError;
+impl<UART: Uart> serial::nb::Read<u8> for Rx<UART> {
+    type Error = serial::ErrorKind;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         let mut buf: u8 = 0;
@@ -563,7 +563,7 @@ impl<UART: Uart> serial::Read<u8> for Rx<UART> {
         match unsafe { uart_read_bytes(UART::port(), &mut buf as *mut u8 as *mut _, 1, 0) } {
             1 => Ok(buf),
             0 => Err(nb::Error::WouldBlock),
-            err => Err(nb::Error::Other(EspError::from(err as i32).unwrap())),
+            _ => Err(nb::Error::Other(serial::ErrorKind::Other)),
         }
     }
 }
@@ -580,8 +580,8 @@ impl<UART: Uart> serial::Read<u8> for Rx<UART> {
 //     }
 // }
 
-impl<UART: Uart> serial::Write<u8> for Tx<UART> {
-    type Error = EspError;
+impl<UART: Uart> serial::nb::Write<u8> for Tx<UART> {
+    type Error = serial::ErrorKind;
 
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
         match unsafe { uart_wait_tx_done(UART::port(), 0) } as u32 {
@@ -595,17 +595,17 @@ impl<UART: Uart> serial::Write<u8> for Tx<UART> {
         // `uart_write_bytes()` returns error (-1) or how many bytes were written
         match unsafe { uart_write_bytes(UART::port(), &byte as *const u8 as *const _, 1) } {
             1 => Ok(()),
-            err => Err(nb::Error::Other(EspError::from(err as i32).unwrap())),
+            _ => Err(nb::Error::Other(serial::ErrorKind::Other)),
         }
     }
 }
 
 impl<UART: Uart> core::fmt::Write for Tx<UART>
 where
-    Tx<UART>: embedded_hal::serial::Write<u8>,
+    Tx<UART>: embedded_hal::serial::nb::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        use embedded_hal::serial::Write;
+        use embedded_hal::serial::nb::Write;
         s.as_bytes()
             .iter()
             .try_for_each(|c| nb::block!(self.write(*c)))

--- a/src/ulp/delay.rs
+++ b/src/ulp/delay.rs
@@ -1,31 +1,21 @@
-use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+use embedded_hal::delay::blocking::DelayUs;
 
 use super::sys::*;
 
 /// Busy-loop based delay for the RiscV ULP coprocessor
 pub struct Ulp;
 
-impl DelayUs<u32> for Ulp {
-    fn delay_us(&mut self, us: u32) {
+impl DelayUs for Ulp {
+    type Error = core::convert::Infallible;
+
+    fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
         delay_cycles(us * ULP_RISCV_CYCLES_PER_US_NUM / ULP_RISCV_CYCLES_PER_US_DENUM);
+        Ok(())
     }
-}
 
-impl DelayUs<u16> for Ulp {
-    fn delay_us(&mut self, us: u16) {
-        DelayUs::<u32>::delay_us(self, us as u32);
-    }
-}
-
-impl DelayMs<u32> for Ulp {
-    fn delay_ms(&mut self, ms: u32) {
+    fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
         delay_cycles(ms * ULP_RISCV_CYCLES_PER_MS);
-    }
-}
-
-impl DelayMs<u16> for Ulp {
-    fn delay_ms(&mut self, ms: u16) {
-        DelayMs::<u32>::delay_ms(self, ms as u32);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR updates everything to `embedded-hal 1.0.0-alpha.6`. 1.0.0 is around the corner so those traits are more less what to expect from v1.0.

This version also adds CAN traits. So this is prerequisite for adding CAN support with https://github.com/esp-rs/esp-idf-hal/pull/27.