### PR TITLE
Add CAN (TWAI) support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ulp = []
 [dependencies]
 nb = "0.1.2"
 mutex-trait = "0.2"
-embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-hal = "=1.0.0-alpha.6"
 esp-idf-sys = { version = "0.28.1", optional = true, default-features = false, features = ["pio"] }
 
 [build-dependencies]

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -262,23 +262,23 @@ impl<ADC: Adc> PoweredAdc<ADC> {
 }
 
 #[cfg(not(feature = "ulp"))]
-impl<ADC, AN, PIN> embedded_hal::adc::OneShot<AN, u16, PIN> for PoweredAdc<ADC>
+impl<ADC, AN, PIN> embedded_hal::adc::nb::OneShot<AN, u16, PIN> for PoweredAdc<ADC>
 where
     ADC: Adc,
     AN: Analog<ADC>,
-    PIN: embedded_hal::adc::Channel<AN, ID = u8>,
+    PIN: embedded_hal::adc::nb::Channel<AN, ID = u8>,
 {
     type Error = EspError;
 
-    fn read(&mut self, _pin: &mut PIN) -> nb::Result<u16, Self::Error> {
+    fn read(&mut self, pin: &mut PIN) -> nb::Result<u16, Self::Error> {
         let mut measurement = 0_i32;
 
         if ADC::unit() == adc_unit_t_ADC_UNIT_1 {
-            measurement = unsafe { adc1_get_raw(PIN::channel() as adc_channel_t) };
+            measurement = unsafe { adc1_get_raw(pin.channel() as adc_channel_t) };
         } else {
             let res = unsafe {
                 adc2_get_raw(
-                    PIN::channel() as adc_channel_t,
+                    pin.channel() as adc_channel_t,
                     self.resolution.into(),
                     &mut measurement as *mut _,
                 )
@@ -296,7 +296,7 @@ where
 }
 
 #[cfg(all(esp32, not(feature = "ulp")))]
-impl embedded_hal::adc::OneShot<ADC1, u16, hall::HallSensor> for PoweredAdc<ADC1> {
+impl embedded_hal::adc::nb::OneShot<ADC1, u16, hall::HallSensor> for PoweredAdc<ADC1> {
     type Error = EspError;
 
     fn read(&mut self, _hall_sensor: &mut hall::HallSensor) -> nb::Result<u16, Self::Error> {

--- a/src/can.rs
+++ b/src/can.rs
@@ -7,7 +7,11 @@ use crate::delay::{portMAX_DELAY, TickType};
 use crate::gpio::*;
 use core::marker::PhantomData;
 use core::time::Duration;
+use embedded_hal::can::Frame as _;
 use esp_idf_sys::*;
+
+pub use embedded_hal::can::ExtendedId;
+pub use embedded_hal::can::StandardId;
 
 /// CAN timing
 pub enum Timing {
@@ -253,6 +257,17 @@ impl<TX: OutputPin, RX: InputPin> embedded_hal::can::nb::Can for CanBus<TX, RX> 
 }
 
 pub struct Frame(twai_message_t);
+
+impl core::fmt::Display for Frame {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "Frame {{ id: {:?}, data: {:?} }}",
+            self.id(),
+            self.data()
+        )
+    }
+}
 
 impl embedded_hal::can::Frame for Frame {
     fn new(id: impl Into<embedded_hal::can::Id>, data: &[u8]) -> Option<Self> {

--- a/src/can.rs
+++ b/src/can.rs
@@ -13,160 +13,205 @@ use esp_idf_sys::*;
 pub use embedded_hal::can::ExtendedId;
 pub use embedded_hal::can::StandardId;
 
-/// CAN timing
-pub enum Timing {
-    B25K,
-    B50K,
-    B100K,
-    B125K,
-    B250K,
-    B500K,
-    B800K,
-    B1M,
-}
+pub mod config {
+    use esp_idf_sys::*;
 
-impl Timing {
-    fn timing(&self) -> twai_timing_config_t {
-        match self {
-            Timing::B25K => twai_timing_config_t {
-                brp: 128,
-                tseg_1: 16,
-                tseg_2: 8,
-                sjw: 3,
-                triple_sampling: false,
-            },
-            Timing::B50K => twai_timing_config_t {
-                brp: 80,
-                tseg_1: 15,
-                tseg_2: 4,
-                sjw: 3,
-                triple_sampling: false,
-            },
-            Timing::B100K => twai_timing_config_t {
-                brp: 40,
-                tseg_1: 15,
-                tseg_2: 4,
-                sjw: 3,
-                triple_sampling: false,
-            },
-            Timing::B125K => twai_timing_config_t {
-                brp: 32,
-                tseg_1: 15,
-                tseg_2: 4,
-                sjw: 3,
-                triple_sampling: false,
-            },
-            Timing::B250K => twai_timing_config_t {
-                brp: 16,
-                tseg_1: 15,
-                tseg_2: 4,
-                sjw: 3,
-                triple_sampling: false,
-            },
-            Timing::B500K => twai_timing_config_t {
-                brp: 8,
-                tseg_1: 15,
-                tseg_2: 4,
-                sjw: 3,
-                triple_sampling: false,
-            },
-            Timing::B800K => twai_timing_config_t {
-                brp: 4,
-                tseg_1: 16,
-                tseg_2: 8,
-                sjw: 3,
-                triple_sampling: false,
-            },
-            Timing::B1M => twai_timing_config_t {
-                brp: 4,
-                tseg_1: 15,
-                tseg_2: 4,
-                sjw: 3,
-                triple_sampling: false,
-            },
-        }
+    /// CAN timing
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+    pub enum Timing {
+        B25K,
+        B50K,
+        B100K,
+        B125K,
+        B250K,
+        B500K,
+        B800K,
+        B1M,
     }
-}
 
-/// Is used to filter out unwanted CAN IDs (messages).
-///
-/// Notice that Espressif TWAI (CAN in rest of the world) acceptance filtering
-/// works differently than common CAN filtering (for example mask bits are inversed).
-/// However here those differences are hidden away from the user and common CAN filtering can be used.
-///
-/// `mask` is used to determine which bits in the CAN ID are compared with the `filter`.
-/// If a mask bit is set to a zero, the corresponding CAN ID bit will be accepted,
-/// regardless of the value of the filter bit.
-///
-/// `filter` determines which bits must be set in the CAN ID to accept the frame,
-/// however `mask` can relax those constraints if its bit is set to zero.
-///
-/// ## Examples
-///
-/// This shows how 11 bit CAN ID `0x3AA` goes through filtering engine and is finally accepted:
-/// ```
-/// // can id    [ 0 1 1 1 0 1 0 1 0 1 0 ]
-/// // mask      [ 1 0 1 0 0 1 1 1 0 0 0 ]
-/// //             1 = compare
-/// //             0 = do not care
-/// // masked id [ 0 _ 1 _ _ 1 0 1 _ _ _ ]
-/// // filter    [ 0 0 1 1 1 1 0 1 0 1 1 ]
-///
-/// // can id    [ 0 1 1 1 0 1 0 1 0 1 0 ]
-/// // accepted
-/// ```
-///
-/// Notice that for example `0x7AA` would not be accepted because its MSB bit is `1`,
-/// but `filter` only accepts `0` in this bit position and `mask` says that this bit must be compared.
-///
-/// Accept only CAN ID `0x567`
-/// ```
-/// let filter = 0x567;
-/// // every bit must match filter
-/// let mask   = 0x7FF;
-/// let f = Filter::Standard { filter, mask };
-/// ```
-///
-/// Accept CAN IDs `0x560 - 0x56F`
-/// ```
-/// let filter = 0x560;
-/// // do not care about 4 LSB bits
-/// let mask   = 0x7F0;
-/// let f = Filter::Standard { filter, mask };
-/// ```
-pub enum Filter {
-    // Filter for 11 bit standard CAN IDs
-    Standard { filter: u16, mask: u16 },
-    // Filter for 29 bit extended CAN IDs
-    Extended { filter: u32, mask: u32 },
-}
-
-impl Filter {
-    /// Filter that allows all standard CAN IDs.
-    pub fn standard_allow_all() -> Self {
-        Self::Standard {
-            filter: 0,
-            mask: 0x7FF,
+    impl From<Timing> for twai_timing_config_t {
+        fn from(resolution: Timing) -> Self {
+            match resolution {
+                Timing::B25K => twai_timing_config_t {
+                    brp: 128,
+                    tseg_1: 16,
+                    tseg_2: 8,
+                    sjw: 3,
+                    triple_sampling: false,
+                },
+                Timing::B50K => twai_timing_config_t {
+                    brp: 80,
+                    tseg_1: 15,
+                    tseg_2: 4,
+                    sjw: 3,
+                    triple_sampling: false,
+                },
+                Timing::B100K => twai_timing_config_t {
+                    brp: 40,
+                    tseg_1: 15,
+                    tseg_2: 4,
+                    sjw: 3,
+                    triple_sampling: false,
+                },
+                Timing::B125K => twai_timing_config_t {
+                    brp: 32,
+                    tseg_1: 15,
+                    tseg_2: 4,
+                    sjw: 3,
+                    triple_sampling: false,
+                },
+                Timing::B250K => twai_timing_config_t {
+                    brp: 16,
+                    tseg_1: 15,
+                    tseg_2: 4,
+                    sjw: 3,
+                    triple_sampling: false,
+                },
+                Timing::B500K => twai_timing_config_t {
+                    brp: 8,
+                    tseg_1: 15,
+                    tseg_2: 4,
+                    sjw: 3,
+                    triple_sampling: false,
+                },
+                Timing::B800K => twai_timing_config_t {
+                    brp: 4,
+                    tseg_1: 16,
+                    tseg_2: 8,
+                    sjw: 3,
+                    triple_sampling: false,
+                },
+                Timing::B1M => twai_timing_config_t {
+                    brp: 4,
+                    tseg_1: 15,
+                    tseg_2: 4,
+                    sjw: 3,
+                    triple_sampling: false,
+                },
+            }
         }
     }
 
-    /// Filter that accepts all extended CAN IDs.
-    pub fn extended_allow_all() -> Self {
-        Self::Extended {
-            filter: 0,
-            mask: 0x1FFFFFFF,
+    impl Default for Timing {
+        fn default() -> Self {
+            Self::B500K
+        }
+    }
+
+    /// Is used to filter out unwanted CAN IDs (messages).
+    ///
+    /// Notice that Espressif TWAI (CAN in rest of the world) acceptance filtering
+    /// works differently than common CAN filtering (for example mask bits are inversed).
+    /// However here those differences are hidden away from the user and common CAN filtering can be used.
+    ///
+    /// `mask` is used to determine which bits in the CAN ID are compared with the `filter`.
+    /// If a mask bit is set to a zero, the corresponding CAN ID bit will be accepted,
+    /// regardless of the value of the filter bit.
+    ///
+    /// `filter` determines which bits must be set in the CAN ID to accept the frame,
+    /// however `mask` can relax those constraints if its bit is set to zero.
+    ///
+    /// ## Examples
+    ///
+    /// This shows how 11 bit CAN ID `0x3AA` goes through filtering engine and is finally accepted:
+    /// ```
+    /// // can id    [ 0 1 1 1 0 1 0 1 0 1 0 ]
+    /// // mask      [ 1 0 1 0 0 1 1 1 0 0 0 ]
+    /// //             1 = compare
+    /// //             0 = do not care
+    /// // masked id [ 0 _ 1 _ _ 1 0 1 _ _ _ ]
+    /// // filter    [ 0 0 1 1 1 1 0 1 0 1 1 ]
+    ///
+    /// // can id    [ 0 1 1 1 0 1 0 1 0 1 0 ]
+    /// // accepted
+    /// ```
+    ///
+    /// Notice that for example `0x7AA` would not be accepted because its MSB bit is `1`,
+    /// but `filter` only accepts `0` in this bit position and `mask` says that this bit must be compared.
+    ///
+    /// Accept only CAN ID `0x567`
+    /// ```
+    /// let filter = 0x567;
+    /// // every bit must match filter
+    /// let mask   = 0x7FF;
+    /// let f = Filter::Standard { filter, mask };
+    /// ```
+    ///
+    /// Accept CAN IDs `0x560 - 0x56F`
+    /// ```
+    /// let filter = 0x560;
+    /// // do not care about 4 LSB bits
+    /// let mask   = 0x7F0;
+    /// let f = Filter::Standard { filter, mask };
+    /// ```
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+    pub enum Filter {
+        // Filter for 11 bit standard CAN IDs
+        Standard { filter: u16, mask: u16 },
+        // Filter for 29 bit extended CAN IDs
+        Extended { filter: u32, mask: u32 },
+    }
+
+    impl Filter {
+        /// Filter that allows all standard CAN IDs.
+        pub fn standard_allow_all() -> Self {
+            Self::Standard {
+                filter: 0,
+                mask: 0x7FF,
+            }
+        }
+
+        /// Filter that accepts all extended CAN IDs.
+        pub fn extended_allow_all() -> Self {
+            Self::Extended {
+                filter: 0,
+                mask: 0x1FFFFFFF,
+            }
+        }
+    }
+
+    impl Default for Filter {
+        fn default() -> Self {
+            Filter::standard_allow_all()
+        }
+    }
+
+    #[derive(Debug, Copy, Clone, Default)]
+    pub struct Config {
+        pub timing: Timing,
+        pub filter: Filter,
+    }
+
+    impl Config {
+        pub fn new() -> Self {
+            Default::default()
+        }
+
+        #[must_use]
+        pub fn timing(mut self, timing: Timing) -> Self {
+            self.timing = timing;
+            self
+        }
+
+        #[must_use]
+        pub fn filter(mut self, filter: Filter) -> Self {
+            self.filter = filter;
+            self
         }
     }
 }
 
 /// CAN abstraction
 pub struct CanBus<TX: OutputPin, RX: InputPin> {
-    tx: PhantomData<TX>,
-    rx: PhantomData<RX>,
+    can: CAN,
+    tx: TX,
+    rx: RX,
 }
 
+unsafe impl<TX: OutputPin, RX: InputPin> Send for CanBus<TX, RX> {}
+
 impl<TX: OutputPin, RX: InputPin> CanBus<TX, RX> {
-    pub fn new(tx: TX, rx: RX, timing: Timing, filter: Filter) -> Result<Self, EspError> {
+    pub fn new(can: CAN, tx: TX, rx: RX, config: config::Config) -> Result<Self, EspError> {
         let general_config = twai_general_config_t {
             mode: twai_mode_t_TWAI_MODE_NORMAL,
             tx_io: tx.pin(),
@@ -180,12 +225,14 @@ impl<TX: OutputPin, RX: InputPin> CanBus<TX, RX> {
             intr_flags: ESP_INTR_FLAG_LEVEL1 as i32,
         };
 
-        let timing_config = timing.timing();
+        let timing_config = config.timing.into();
 
         // modify filter and mask to be compatible with TWAI acceptance filter
-        let (filter, mask) = match filter {
-            Filter::Standard { filter, mask } => ((filter as u32) << 21, !((mask as u32) << 21)),
-            Filter::Extended { filter, mask } => (filter << 3, !(mask << 3)),
+        let (filter, mask) = match config.filter {
+            config::Filter::Standard { filter, mask } => {
+                ((filter as u32) << 21, !((mask as u32) << 21))
+            }
+            config::Filter::Extended { filter, mask } => (filter << 3, !(mask << 3)),
         };
 
         let filter_config = twai_filter_config_t {
@@ -197,10 +244,13 @@ impl<TX: OutputPin, RX: InputPin> CanBus<TX, RX> {
         esp!(unsafe { twai_driver_install(&general_config, &timing_config, &filter_config) })?;
         esp!(unsafe { twai_start() })?;
 
-        Ok(Self {
-            tx: PhantomData,
-            rx: PhantomData,
-        })
+        Ok(Self { can, tx, rx })
+    }
+
+    pub fn release(self) -> Result<(CAN, TX, RX), EspError> {
+        esp!(unsafe { twai_driver_uninstall() })?;
+
+        Ok((self.can, self.tx, self.rx))
     }
 }
 
@@ -370,3 +420,16 @@ impl embedded_hal::can::Frame for Frame {
         &self.0.data[..self.dlc()]
     }
 }
+
+pub struct CAN(PhantomData<*const ()>);
+
+impl CAN {
+    /// # Safety
+    ///
+    /// Care should be taken not to instnatiate this CAN instance, if it is already instantiated and used elsewhere
+    pub unsafe fn new() -> Self {
+        CAN(PhantomData)
+    }
+}
+
+unsafe impl Send for CAN {}

--- a/src/can.rs
+++ b/src/can.rs
@@ -367,6 +367,6 @@ impl embedded_hal::can::Frame for Frame {
     }
 
     fn data(&self) -> &[u8] {
-        &self.0.data
+        &self.0.data[..self.dlc()]
     }
 }

--- a/src/can.rs
+++ b/src/can.rs
@@ -1,0 +1,200 @@
+//! CAN bus peripheral control.
+//! CAN is called Two-Wire Automotive Interface (TWAI) in ESP32 documentation.
+//!
+//! ESP32 has one CAN peripheral.
+//!
+
+use core::marker::PhantomData;
+
+use crate::gpio::*;
+use embedded_hal::can::blocking::Can;
+use esp_idf_sys::*;
+
+/// CAN timing
+pub enum Timing {
+    B25K,
+    B50K,
+    B100K,
+    B125K,
+    B250K,
+    B500K,
+    B800K,
+    B1M,
+}
+
+impl Timing {
+    fn timing(&self) -> twai_timing_config_t {
+        match self {
+            Timing::B25K => twai_timing_config_t {
+                brp: 128,
+                tseg_1: 16,
+                tseg_2: 8,
+                sjw: 3,
+                triple_sampling: false,
+            },
+            Timing::B50K => twai_timing_config_t {
+                brp: 80,
+                tseg_1: 15,
+                tseg_2: 4,
+                sjw: 3,
+                triple_sampling: false,
+            },
+            Timing::B100K => twai_timing_config_t {
+                brp: 40,
+                tseg_1: 15,
+                tseg_2: 4,
+                sjw: 3,
+                triple_sampling: false,
+            },
+            Timing::B125K => twai_timing_config_t {
+                brp: 32,
+                tseg_1: 15,
+                tseg_2: 4,
+                sjw: 3,
+                triple_sampling: false,
+            },
+            Timing::B250K => twai_timing_config_t {
+                brp: 16,
+                tseg_1: 15,
+                tseg_2: 4,
+                sjw: 3,
+                triple_sampling: false,
+            },
+            Timing::B500K => twai_timing_config_t {
+                brp: 8,
+                tseg_1: 15,
+                tseg_2: 4,
+                sjw: 3,
+                triple_sampling: false,
+            },
+            Timing::B800K => twai_timing_config_t {
+                brp: 4,
+                tseg_1: 16,
+                tseg_2: 8,
+                sjw: 3,
+                triple_sampling: false,
+            },
+            Timing::B1M => twai_timing_config_t {
+                brp: 4,
+                tseg_1: 15,
+                tseg_2: 4,
+                sjw: 3,
+                triple_sampling: false,
+            },
+        }
+    }
+}
+
+/// Is used to filter out unwanted CAN IDs (messages).
+///
+/// Notice that Espressif TWAI (CAN in rest of the world) acceptance filtering
+/// works differently than common CAN filtering (for example mask bits are inversed).
+/// However here those differences are hidden away from the user and common CAN filtering can be used.
+///
+/// `mask` is used to determine which bits in the CAN ID are compared with the `filter`.
+/// If a mask bit is set to a zero, the corresponding CAN ID bit will be accepted,
+/// regardless of the value of the filter bit.
+///
+/// `filter` determines which bits must be set in the CAN ID to accept the frame,
+/// however `mask` can relax those constraints if its bit is set to zero.
+///
+/// ## Examples
+///
+/// This shows how 11 bit CAN ID `0x3AA` goes through filtering engine and is finally accepted:
+/// ```
+/// // can id    [ 0 1 1 1 0 1 0 1 0 1 0 ]
+/// // mask      [ 1 0 1 0 0 1 1 1 0 0 0 ]
+/// //             1 = compare
+/// //             0 = do not care
+/// // masked id [ 0 _ 1 _ _ 1 0 1 _ _ _ ]
+/// // filter    [ 0 0 1 1 1 1 0 1 0 1 1 ]
+///
+/// // can id    [ 0 1 1 1 0 1 0 1 0 1 0 ]
+/// // accepted
+/// ```
+///
+/// Notice that for example `0x7AA` would not be accepted because its MSB bit is `1`,
+/// but `filter` only accepts `0` in this bit position and `mask` says that this bit must be compared.
+///
+/// Accept only CAN ID `0x567`
+/// ```
+/// let filter = 0x567;
+/// // every bit must match filter
+/// let mask   = 0x7FF;
+/// let f = Filter::Standard { filter, mask };
+/// ```
+///
+/// Accept CAN IDs `0x560 - 0x56F`
+/// ```
+/// let filter = 0x560;
+/// // do not care about 4 LSB bits
+/// let mask   = 0x7F0;
+/// let f = Filter::Standard { filter, mask };
+/// ```
+pub enum Filter {
+    Standard { filter: u16, mask: u16 },
+    Extended { filter: u32, mask: u32 },
+}
+
+impl Filter {
+    /// Filter that allows all standard CAN IDs.
+    pub fn standard_allow_all() -> Self {
+        Self::Standard {
+            filter: 0,
+            mask: 0x7FF,
+        }
+    }
+
+    /// Filter that accepts all extended CAN IDs.
+    pub fn extended_allow_all() -> Self {
+        Self::Extended {
+            filter: 0,
+            mask: 0x1FFFFFFF,
+        }
+    }
+}
+
+/// CAN abstraction
+pub struct CanBus<TX: OutputPin, RX: InputPin> {
+    tx: PhantomData<TX>,
+    rx: PhantomData<RX>,
+}
+
+impl<TX: OutputPin, RX: InputPin> CanBus<TX, RX> {
+    pub fn new(tx: TX, rx: RX, timing: Timing, filter: Filter) -> Result<Self, EspError> {
+        let general_config = twai_general_config_t {
+            mode: twai_mode_t_TWAI_MODE_NORMAL,
+            tx_io: tx.pin(),
+            rx_io: rx.pin(),
+            clkout_io: -1,
+            bus_off_io: -1,
+            tx_queue_len: 5,
+            rx_queue_len: 5,
+            alerts_enabled: TWAI_ALERT_NONE,
+            clkout_divider: 0,
+            intr_flags: ESP_INTR_FLAG_LEVEL1 as i32,
+        };
+
+        let timing_config = timing.timing();
+
+        // modify filter and mask to be compatible with TWAI acceptance filter
+        let (filter, mask) = match filter {
+            Filter::Standard { filter, mask } => ((filter as u32) << 21, !((mask as u32) << 21)),
+            Filter::Extended { filter, mask } => (filter << 3, !(mask << 3)),
+        };
+
+        let filter_config = twai_filter_config_t {
+            acceptance_code: filter,
+            acceptance_mask: mask,
+            single_filter: true,
+        };
+
+        esp!(unsafe { twai_driver_install(&general_config, &timing_config, &filter_config) })?;
+        esp!(unsafe { twai_start() })?;
+
+        Ok(Self {
+            tx: PhantomData,
+            rx: PhantomData,
+        })
+    }
+}

--- a/src/hall.rs
+++ b/src/hall.rs
@@ -15,10 +15,10 @@ impl HallSensor {
 
 unsafe impl Send for HallSensor {}
 
-impl embedded_hal::adc::Channel<adc::ADC1> for HallSensor {
+impl embedded_hal::adc::nb::Channel<adc::ADC1> for HallSensor {
     type ID = ();
 
-    fn channel() -> Self::ID {
+    fn channel(&self) -> Self::ID {
         ()
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -215,118 +215,137 @@ where
     }
 }
 
-impl<I2C, SDA, SCL> embedded_hal::blocking::i2c::Read for Master<I2C, SDA, SCL>
+impl<I2C, SDA, SCL> embedded_hal::i2c::blocking::Read for Master<I2C, SDA, SCL>
 where
     I2C: I2c,
     SDA: OutputPin + InputPin,
     SCL: OutputPin,
 {
-    type Error = EspError;
+    type Error = embedded_hal::i2c::ErrorKind;
 
     fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        let command_link = CommandLink::new()?;
+        let command_link = CommandLink::new().map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
         unsafe {
-            esp!(i2c_master_start(command_link.0))?;
+            esp!(i2c_master_start(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_READ as u8),
                 true
-            ))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_read(
                 command_link.0,
                 buffer.as_ptr() as *const u8 as *mut u8,
                 buffer.len() as u32,
                 i2c_ack_type_t_I2C_MASTER_LAST_NACK
-            ))?;
-            esp!(i2c_master_stop(command_link.0))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_stop(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
             esp_result!(
                 i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout),
                 ()
             )
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)
         }
     }
 }
 
-impl<I2C, SDA, SCL> embedded_hal::blocking::i2c::Write for Master<I2C, SDA, SCL>
+impl<I2C, SDA, SCL> embedded_hal::i2c::blocking::Write for Master<I2C, SDA, SCL>
 where
     I2C: I2c,
     SDA: OutputPin + InputPin,
     SCL: OutputPin,
 {
-    type Error = EspError;
+    type Error = embedded_hal::i2c::ErrorKind;
 
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
         unsafe {
-            let command_link = CommandLink::new()?;
+            let command_link =
+                CommandLink::new().map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
-            esp!(i2c_master_start(command_link.0))?;
+            esp!(i2c_master_start(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_WRITE as u8),
                 true
-            ))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_write(
                 command_link.0,
                 bytes.as_ptr() as *const u8 as *mut u8,
                 bytes.len() as u32,
                 true
-            ))?;
-            esp!(i2c_master_stop(command_link.0))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_stop(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
             esp_result!(
                 i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout),
                 ()
             )
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)
         }
     }
 }
 
-impl<I2C, SDA, SCL> embedded_hal::blocking::i2c::WriteRead for Master<I2C, SDA, SCL>
+impl<I2C, SDA, SCL> embedded_hal::i2c::blocking::WriteRead for Master<I2C, SDA, SCL>
 where
     I2C: I2c,
     SDA: OutputPin + InputPin,
     SCL: OutputPin,
 {
-    type Error = EspError;
+    type Error = embedded_hal::i2c::ErrorKind;
 
     fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
-        let command_link = CommandLink::new()?;
+        let command_link = CommandLink::new().map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
         unsafe {
-            esp!(i2c_master_start(command_link.0))?;
+            esp!(i2c_master_start(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_WRITE as u8),
                 true
-            ))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_write(
                 command_link.0,
                 bytes.as_ptr() as *const u8 as *mut u8,
                 bytes.len() as u32,
                 true
-            ))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
-            esp!(i2c_master_start(command_link.0))?;
+            esp!(i2c_master_start(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_READ as u8),
                 true
-            ))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
             esp!(i2c_master_read(
                 command_link.0,
                 buffer.as_ptr() as *const u8 as *mut u8,
                 buffer.len() as u32,
                 i2c_ack_type_t_I2C_MASTER_LAST_NACK
-            ))?;
+            ))
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
-            esp!(i2c_master_stop(command_link.0))?;
+            esp!(i2c_master_stop(command_link.0))
+                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
 
             esp_result!(
                 i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout),
                 ()
             )
+            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)
         }
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,6 +1,11 @@
 use crate::{delay::*, gpio::*, units::*};
-
 use esp_idf_sys::*;
+
+crate::embedded_hal_error!(
+    I2cError,
+    embedded_hal::i2c::Error,
+    embedded_hal::i2c::ErrorKind
+);
 
 pub struct MasterPins<SDA: OutputPin + InputPin, SCL: OutputPin> {
     pub sda: SDA,
@@ -221,35 +226,33 @@ where
     SDA: OutputPin + InputPin,
     SCL: OutputPin,
 {
-    type Error = embedded_hal::i2c::ErrorKind;
+    type Error = I2cError;
 
     fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        let command_link = CommandLink::new().map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+        let command_link = CommandLink::new().map_err(I2cError::other)?;
 
         unsafe {
-            esp!(i2c_master_start(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_start(command_link.0)).map_err(I2cError::other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_READ as u8),
                 true
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
             esp!(i2c_master_read(
                 command_link.0,
                 buffer.as_ptr() as *const u8 as *mut u8,
                 buffer.len() as u32,
                 i2c_ack_type_t_I2C_MASTER_LAST_NACK
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
-            esp!(i2c_master_stop(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
+            esp!(i2c_master_stop(command_link.0)).map_err(I2cError::other)?;
 
             esp_result!(
                 i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout),
                 ()
             )
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)
+            .map_err(I2cError::other)
         }
     }
 }
@@ -260,36 +263,33 @@ where
     SDA: OutputPin + InputPin,
     SCL: OutputPin,
 {
-    type Error = embedded_hal::i2c::ErrorKind;
+    type Error = I2cError;
 
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
         unsafe {
-            let command_link =
-                CommandLink::new().map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            let command_link = CommandLink::new().map_err(I2cError::other)?;
 
-            esp!(i2c_master_start(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_start(command_link.0)).map_err(I2cError::other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_WRITE as u8),
                 true
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
             esp!(i2c_master_write(
                 command_link.0,
                 bytes.as_ptr() as *const u8 as *mut u8,
                 bytes.len() as u32,
                 true
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
-            esp!(i2c_master_stop(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
+            esp!(i2c_master_stop(command_link.0)).map_err(I2cError::other)?;
 
             esp_result!(
                 i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout),
                 ()
             )
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)
+            .map_err(I2cError::other)
         }
     }
 }
@@ -300,52 +300,49 @@ where
     SDA: OutputPin + InputPin,
     SCL: OutputPin,
 {
-    type Error = embedded_hal::i2c::ErrorKind;
+    type Error = I2cError;
 
     fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
-        let command_link = CommandLink::new().map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+        let command_link = CommandLink::new().map_err(I2cError::other)?;
 
         unsafe {
-            esp!(i2c_master_start(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_start(command_link.0)).map_err(I2cError::other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_WRITE as u8),
                 true
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
             esp!(i2c_master_write(
                 command_link.0,
                 bytes.as_ptr() as *const u8 as *mut u8,
                 bytes.len() as u32,
                 true
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
 
-            esp!(i2c_master_start(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_start(command_link.0)).map_err(I2cError::other)?;
             esp!(i2c_master_write_byte(
                 command_link.0,
                 (addr << 1) | (i2c_rw_t_I2C_MASTER_READ as u8),
                 true
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
             esp!(i2c_master_read(
                 command_link.0,
                 buffer.as_ptr() as *const u8 as *mut u8,
                 buffer.len() as u32,
                 i2c_ack_type_t_I2C_MASTER_LAST_NACK
             ))
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            .map_err(I2cError::other)?;
 
-            esp!(i2c_master_stop(command_link.0))
-                .map_err(|_| embedded_hal::i2c::ErrorKind::Other)?;
+            esp!(i2c_master_stop(command_link.0)).map_err(I2cError::other)?;
 
             esp_result!(
                 i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout),
                 ()
             )
-            .map_err(|_| embedded_hal::i2c::ErrorKind::Other)
+            .map_err(I2cError::other)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ compile_error!("Feature `ulp` is currently only supported on esp32s2");
 pub mod ulp;
 pub mod adc;
 #[cfg(not(feature = "ulp"))]
+pub mod can;
+#[cfg(not(feature = "ulp"))]
 pub mod delay;
 pub mod gpio;
 #[cfg(esp32)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,3 +27,59 @@ pub mod units;
 
 #[cfg(feature = "ulp")]
 pub use crate::ulp::delay;
+
+// This is used to create `embedded_hal` compatible error structs
+// that preserve original `EspError`.
+//
+// Example:
+// embedded_hal_error!(I2cError, embedded_hal::i2c::Error, embedded_hal::i2c::ErrorKind)
+macro_rules! embedded_hal_error {
+    ($error:ident, $errortrait:ty, $kind:ty) => {
+        #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+        pub struct $error {
+            kind: $kind,
+            cause: esp_idf_sys::EspError,
+        }
+
+        impl $error {
+            pub fn new(kind: $kind, cause: esp_idf_sys::EspError) -> Self {
+                Self { kind, cause }
+            }
+            pub fn other(cause: esp_idf_sys::EspError) -> Self {
+                Self::new(<$kind>::Other, cause)
+            }
+            pub fn cause(&self) -> esp_idf_sys::EspError {
+                self.cause
+            }
+        }
+
+        impl From<esp_idf_sys::EspError> for $error {
+            fn from(e: esp_idf_sys::EspError) -> Self {
+                Self::other(e)
+            }
+        }
+
+        impl $errortrait for $error {
+            fn kind(&self) -> $kind {
+                self.kind
+            }
+        }
+
+        impl core::fmt::Display for $error {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                write!(
+                    f,
+                    "{} {{ kind: {}, cause: {} }}",
+                    stringify!($error),
+                    self.kind,
+                    self.cause()
+                )
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl std::error::Error for $error {}
+    };
+}
+
+pub(crate) use embedded_hal_error;

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -7,6 +7,8 @@ use esp_idf_sys::EspMutex;
 use crate::ulp::sys::EspMutex;
 
 use crate::adc;
+#[cfg(not(feature = "ulp"))]
+use crate::can;
 use crate::gpio;
 #[cfg(esp32)]
 use crate::hall;
@@ -39,6 +41,8 @@ pub struct Peripherals {
     pub adc2: adc::ADC2,
     #[cfg(esp32)]
     pub hall_sensor: hall::HallSensor,
+    #[cfg(not(feature = "ulp"))]
+    pub can: can::CAN,
 }
 
 static mut TAKEN: EspMutex<bool> = EspMutex::new(false);
@@ -83,6 +87,8 @@ impl Peripherals {
             adc2: adc::ADC2::new(),
             #[cfg(esp32)]
             hall_sensor: hall::HallSensor::new(),
+            #[cfg(not(feature = "ulp"))]
+            can: can::CAN::new(),
         }
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,6 +9,7 @@
 pub use crate::peripherals::*;
 pub use crate::units::*;
 
+pub use embedded_hal::can::Frame as _;
 pub use embedded_hal::digital::blocking::InputPin as _;
 pub use embedded_hal::digital::blocking::OutputPin as _;
 pub use embedded_hal::digital::blocking::StatefulOutputPin as _;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,9 +9,8 @@
 pub use crate::peripherals::*;
 pub use crate::units::*;
 
-pub use embedded_hal::digital::v2::InputPin as _;
-pub use embedded_hal::digital::v2::OutputPin as _;
-pub use embedded_hal::digital::v2::StatefulOutputPin as _;
-pub use embedded_hal::digital::v2::ToggleableOutputPin as _;
-pub use embedded_hal::prelude::*;
-pub use embedded_hal::timer::{Cancel, CountDown, Periodic};
+pub use embedded_hal::digital::blocking::InputPin as _;
+pub use embedded_hal::digital::blocking::OutputPin as _;
+pub use embedded_hal::digital::blocking::StatefulOutputPin as _;
+pub use embedded_hal::digital::blocking::ToggleableOutputPin as _;
+pub use embedded_hal::timer::nb::{Cancel, CountDown};

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -44,8 +44,6 @@ use core::ptr;
 
 use embedded_hal::serial;
 
-//use crate::prelude::*;
-
 use crate::gpio::*;
 use crate::units::*;
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -500,20 +500,20 @@ impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin>
     // }
 }
 
-impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> serial::Read<u8>
+impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> serial::nb::Read<u8>
     for Serial<UART, TX, RX, CTS, RTS>
 {
-    type Error = EspError;
+    type Error = serial::ErrorKind;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self.rx.read()
     }
 }
 
-impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> serial::Write<u8>
+impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> serial::nb::Write<u8>
     for Serial<UART, TX, RX, CTS, RTS>
 {
-    type Error = EspError;
+    type Error = serial::ErrorKind;
 
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
         self.tx.flush()
@@ -528,7 +528,7 @@ impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> cor
     for Serial<UART, TX, RX, CTS, RTS>
 {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        use embedded_hal::serial::Write;
+        use embedded_hal::serial::nb::Write;
         s.as_bytes()
             .iter()
             .try_for_each(|c| nb::block!(self.write(*c)))
@@ -552,8 +552,8 @@ impl<UART: Uart> Rx<UART> {
     // }
 }
 
-impl<UART: Uart> serial::Read<u8> for Rx<UART> {
-    type Error = EspError;
+impl<UART: Uart> serial::nb::Read<u8> for Rx<UART> {
+    type Error = serial::ErrorKind;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         let mut buf: u8 = 0;
@@ -563,7 +563,7 @@ impl<UART: Uart> serial::Read<u8> for Rx<UART> {
         match unsafe { uart_read_bytes(UART::port(), &mut buf as *mut u8 as *mut _, 1, 0) } {
             1 => Ok(buf),
             0 => Err(nb::Error::WouldBlock),
-            err => Err(nb::Error::Other(EspError::from(err as i32).unwrap())),
+            _ => Err(nb::Error::Other(serial::ErrorKind::Other)),
         }
     }
 }
@@ -580,8 +580,8 @@ impl<UART: Uart> serial::Read<u8> for Rx<UART> {
 //     }
 // }
 
-impl<UART: Uart> serial::Write<u8> for Tx<UART> {
-    type Error = EspError;
+impl<UART: Uart> serial::nb::Write<u8> for Tx<UART> {
+    type Error = serial::ErrorKind;
 
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
         match unsafe { uart_wait_tx_done(UART::port(), 0) } as u32 {
@@ -595,17 +595,17 @@ impl<UART: Uart> serial::Write<u8> for Tx<UART> {
         // `uart_write_bytes()` returns error (-1) or how many bytes were written
         match unsafe { uart_write_bytes(UART::port(), &byte as *const u8 as *const _, 1) } {
             1 => Ok(()),
-            err => Err(nb::Error::Other(EspError::from(err as i32).unwrap())),
+            _ => Err(nb::Error::Other(serial::ErrorKind::Other)),
         }
     }
 }
 
 impl<UART: Uart> core::fmt::Write for Tx<UART>
 where
-    Tx<UART>: embedded_hal::serial::Write<u8>,
+    Tx<UART>: embedded_hal::serial::nb::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        use embedded_hal::serial::Write;
+        use embedded_hal::serial::nb::Write;
         s.as_bytes()
             .iter()
             .try_for_each(|c| nb::block!(self.write(*c)))

--- a/src/ulp/delay.rs
+++ b/src/ulp/delay.rs
@@ -1,31 +1,21 @@
-use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+use embedded_hal::delay::blocking::DelayUs;
 
 use super::sys::*;
 
 /// Busy-loop based delay for the RiscV ULP coprocessor
 pub struct Ulp;
 
-impl DelayUs<u32> for Ulp {
-    fn delay_us(&mut self, us: u32) {
+impl DelayUs for Ulp {
+    type Error = core::convert::Infallible;
+
+    fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
         delay_cycles(us * ULP_RISCV_CYCLES_PER_US_NUM / ULP_RISCV_CYCLES_PER_US_DENUM);
+        Ok(())
     }
-}
 
-impl DelayUs<u16> for Ulp {
-    fn delay_us(&mut self, us: u16) {
-        DelayUs::<u32>::delay_us(self, us as u32);
-    }
-}
-
-impl DelayMs<u32> for Ulp {
-    fn delay_ms(&mut self, ms: u32) {
+    fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
         delay_cycles(ms * ULP_RISCV_CYCLES_PER_MS);
-    }
-}
-
-impl DelayMs<u16> for Ulp {
-    fn delay_ms(&mut self, ms: u16) {
-        DelayMs::<u32>::delay_ms(self, ms as u32);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR adds CAN (TWAI in ESP documentaion) support.
It depends on `embedded-hal 1.0.0-alpha.6` which is added with separate PR: https://github.com/esp-rs/esp-idf-hal/pull/26. 