### PR TITLE
Re-export `embedded-hal` traits in prelude

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,5 +6,30 @@
 //!
 //! This can be imported as `use esp_idf_hal::prelude::*`.
 
+pub use embedded_hal::{
+    adc::nb::{Channel as _, OneShot as _},
+    can::{Error as _, Frame as _},
+    delay::blocking::DelayUs as _,
+    digital::blocking::{
+        InputPin as _, OutputPin as _, StatefulOutputPin as _, ToggleableOutputPin as _,
+    },
+    i2c::{
+        blocking::{Read as _, Write as _, WriteRead as _},
+        Error as _,
+    },
+    serial::{
+        nb::{Read as _, Write as _},
+        Error as _,
+    },
+    spi::{
+        blocking::{
+            Read as _, Transactional as _, Transfer as _, TransferInplace as _, Write as _,
+            WriteIter as _,
+        },
+        Error as _,
+    },
+};
+pub use embedded_hal_0_2::prelude::*;
+
 pub use crate::peripherals::*;
 pub use crate::units::*;


### PR DESCRIPTION
I'm using this crate in a project and needed some of the `embedded-hal` traits in scope. I didn't otherwise require the crate, so it seemed a little silly to add it as a dependency. Instead, we can re-export the traits in the prelude.

I believe this covers everything that has been implemented so far.