### PR TITLE
Migrate llvm_asm! to asm!

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,3 +1,4 @@
+use core::arch::asm;
 use esp_idf_sys::*;
 
 /// Returns the number of cores supported by the esp32* chip
@@ -20,9 +21,8 @@ pub fn core() -> u32 {
     let mut core = 0;
 
     #[cfg(any(esp32, esp32s3))]
-    #[allow(deprecated)]
     unsafe {
-        llvm_asm!("rsr.prid $0\nextui $0,$0,13,1" : "=r"(core) : : : "volatile");
+        asm!("rsr.prid {0}", "extui {0},{0},13,1", out(reg) core);
     }
 
     core

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(llvm_asm)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(generic_associated_types)] // For mutex
 

--- a/src/ulp/sys/cpu.rs
+++ b/src/ulp/sys/cpu.rs
@@ -11,15 +11,15 @@ pub const ULP_RISCV_CYCLES_PER_MS: u32 =
 
 use crate::ulp::pac::*;
 use crate::ulp::reg::*;
+use core::arch::asm;
 
 #[inline(always)]
 pub fn get_ccount() -> u32 {
     #[allow(unused_assignments)]
     let mut ccount = 0;
 
-    #[allow(deprecated)]
     unsafe {
-        llvm_asm!("rdcycle $0" : "=r"(ccount) : : : "volatile");
+        asm!("rdcycle {}", out(reg) ccount);
     }
 
     ccount


### PR DESCRIPTION
According to https://github.com/rust-lang/rust/issues/70173#issuecomment-1012092455, `asm!` got stabilized in nightly and `llvm_asm!`

Migrating to `asm!` makes this crate compile again with nightly 2022-01-17 for me. Thank you @jessebraham for pointing me to the issue above!