### PR TITLE
Conditionally import asm! macro at src/cpu.rs

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,3 +1,4 @@
+#[cfg(any(esp32, esp32s3))]
 use core::arch::asm;
 
 use esp_idf_sys::*;


### PR DESCRIPTION
This avoids a compiler warning on single-core targets which do not perform an actual check. This fixes #36. Sorry that i missed this in the first place.