### PR TITLE
Keep all SPI sub-operations within a single transaction

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -471,12 +471,15 @@ impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: O
         write_len: usize,
         keep_cs_active: bool,
     ) -> Result<(), SpiError> {
+        let mut flags = 0;
+
+        #[cfg(any(esp_idf_version = "4.4", esp_idf_version_major = "5"))]
+        if keep_cs_active {
+            flags |= SPI_TRANS_CS_KEEP_ACTIVE;
+        }
+
         let mut transaction = spi_transaction_t {
-            flags: if keep_cs_active {
-                SPI_TRANS_CS_KEEP_ACTIVE
-            } else {
-                0
-            },
+            flags,
             __bindgen_anon_1: spi_transaction_t__bindgen_ty_1 {
                 tx_buffer: write as *const _,
             },

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -444,15 +444,14 @@ impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: O
                 break;
             }
 
-            let is_last_chunk;
-            if offset == buf.len() {
+            let is_last_chunk = if offset == buf.len() {
                 if lock.is_none() {
                     lock = Some(self.lock_bus()?);
                 }
-                is_last_chunk = false;
+                false
             } else {
-                is_last_chunk = true;
-            }
+                true
+            };
 
             let chunk = &mut buf[..offset];
             let ptr = chunk.as_mut_ptr();
@@ -473,7 +472,7 @@ impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: O
     ) -> Result<(), SpiError> {
         let flags = 0;
 
-        #[cfg(any(esp_idf_version = "4.4", esp_idf_version_major = "5"))]
+        #[cfg(not(esp_idf_version = "4.3"))]
         let flags = if _keep_cs_active {
             flags | SPI_TRANS_CS_KEEP_ACTIVE
         } else {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -475,7 +475,7 @@ impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: O
 
         #[cfg(any(esp_idf_version = "4.4", esp_idf_version_major = "5"))]
         let flags = if _keep_cs_active {
-            flags | SPI_TRANS_CS_KEEP_ACTIVE;
+            flags | SPI_TRANS_CS_KEEP_ACTIVE
         } else {
             flags
         };

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -469,14 +469,16 @@ impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: O
         read_len: usize,
         write: *const u8,
         write_len: usize,
-        keep_cs_active: bool,
+        _keep_cs_active: bool,
     ) -> Result<(), SpiError> {
-        let mut flags = 0;
+        let flags = 0;
 
         #[cfg(any(esp_idf_version = "4.4", esp_idf_version_major = "5"))]
-        if keep_cs_active {
-            flags |= SPI_TRANS_CS_KEEP_ACTIVE;
-        }
+        let flags = if _keep_cs_active {
+            flags | SPI_TRANS_CS_KEEP_ACTIVE;
+        } else {
+            flags
+        };
 
         let mut transaction = spi_transaction_t {
             flags,


### PR DESCRIPTION
Starts to address #48 .

This makes sure that calls to `transfer`, `write`, `read` and `transfer_inplace` regardless of how big the given buffer is happens within a single transaction. Users who wish to break up their transactions can easily do so themselves by calling these operations multiple times.

This doesn't fix `exec` yet as I want to start small.
