### PR TITLE
add interrupt subscription

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -477,6 +477,9 @@ macro_rules! impl_pull {
     };
 }
 
+// Clippy in the CI seems to wrongfully catch a only_used_in_recursion
+// lint error in this function. We'll ignore it until it's fixed.
+#[allow(clippy::only_used_in_recursion)]
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 unsafe fn register_irq_handler(pin_number: usize, p: PinNotifySubscription) {
     chip::IRQ_HANDLERS[pin_number] = Some(p);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -134,12 +134,12 @@ pub struct Unknown;
 pub struct Subscribed;
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "std"))]
-struct UnsafeCallback(*mut Box<dyn for<'a> FnMut() + 'static>);
+struct UnsafeCallback(*mut Box<dyn FnMut() + 'static>);
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "std"))]
 impl UnsafeCallback {
     #[allow(clippy::type_complexity)]
-    pub fn from(boxed: &mut Box<Box<dyn for<'a> FnMut() + 'static>>) -> Self {
+    pub fn from(boxed: &mut Box<Box<dyn FnMut() + 'static>>) -> Self {
         Self(boxed.as_mut())
     }
 
@@ -186,7 +186,7 @@ fn enable_isr_service() -> Result<(), EspError> {
 }
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "std"))]
-type ClosureBox = Box<Box<dyn for<'a> FnMut()>>;
+type ClosureBox = Box<Box<dyn FnMut()>>;
 
 /// The PinNotifySubscription represents the association between an InputPin and
 /// a registered isr handler.
@@ -196,7 +196,7 @@ pub(crate) struct PinNotifySubscription(i32, ClosureBox);
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "std"))]
 impl PinNotifySubscription {
-    fn subscribe<P>(pin: &mut P, callback: impl for<'a> FnMut() + 'static) -> Result<Self, EspError>
+    fn subscribe<P>(pin: &mut P, callback: impl FnMut() + 'static) -> Result<Self, EspError>
     where
         P: InputPin + Pin,
     {
@@ -204,7 +204,7 @@ impl PinNotifySubscription {
 
         let pin_number: i32 = pin.pin();
 
-        let callback: Box<dyn for<'a> FnMut() + 'static> = Box::new(callback);
+        let callback: Box<dyn FnMut() + 'static> = Box::new(callback);
         let mut callback = Box::new(callback);
 
         let unsafe_callback = UnsafeCallback::from(&mut callback);
@@ -521,7 +521,7 @@ macro_rules! impl_input_base {
             /// interrupt handler. So you should take care of what is done in it.
             pub unsafe fn into_subscribed(
                 mut self,
-                callback: impl for<'a> FnMut() + 'static,
+                callback: impl FnMut() + 'static,
                 interrupt_type: InterruptType,
             ) -> Result<$pxi<Subscribed>, EspError> {
                 self.enable_interrupt()?;

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -472,6 +472,11 @@ macro_rules! impl_pull {
     };
 }
 
+/// # Safety
+///
+/// - Access to `IRQ_HANDLERS` is not guarded because we only call register
+///   from the context of Pin which is owned and in the rights state
+///
 // Clippy in the CI seems to wrongfully catch a only_used_in_recursion
 // lint error in this function. We'll ignore it until it's fixed.
 #[allow(clippy::only_used_in_recursion)]
@@ -480,6 +485,11 @@ unsafe fn register_irq_handler(pin_number: usize, p: PinNotifySubscription) {
     chip::IRQ_HANDLERS[pin_number] = Some(p);
 }
 
+/// # Safety
+///
+/// - Access to `IRQ_HANDLERS` is not guarded because we only call register
+///   from the context of Pin which is owned and in the rights state
+///
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 unsafe fn unregister_irq_handler(pin_number: usize) {
     chip::IRQ_HANDLERS[pin_number].take();

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -561,6 +561,9 @@ macro_rules! impl_input_base {
 
         impl_base!($pxi);
         impl_hal_input_pin!($pxi: Input);
+
+        #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "std"))]
+        impl_hal_input_pin!($pxi: SubscribedInput);
     };
 }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -2,10 +2,10 @@
 
 use core::marker::PhantomData;
 
-#[cfg(feature = "std")]
-use std::boxed::Box;
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 
 #[cfg(not(feature = "riscv-ulp-hal"))]
@@ -123,10 +123,7 @@ pub trait TouchPin: Pin {
     fn touch_channel(&self) -> touch_pad_t;
 }
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 pub trait SubscribedPin: Pin {}
 
 pub struct Input;
@@ -139,22 +136,13 @@ pub struct Disabled;
 
 pub struct Unknown;
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 pub struct SubscribedInput;
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 struct UnsafeCallback(*mut Box<dyn FnMut() + 'static>);
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 impl UnsafeCallback {
     #[allow(clippy::type_complexity)]
     pub fn from(boxed: &mut Box<Box<dyn FnMut() + 'static>>) -> Self {
@@ -176,26 +164,17 @@ impl UnsafeCallback {
     }
 }
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 static ISR_SERVICE_ENABLED: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 unsafe extern "C" fn irq_handler(unsafe_callback: *mut esp_idf_sys::c_types::c_void) {
     let mut unsafe_callback = UnsafeCallback::from_ptr(unsafe_callback);
     unsafe_callback.call();
 }
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 fn enable_isr_service() -> Result<(), EspError> {
     if ISR_SERVICE_ENABLED.compare_exchange(
         false,
@@ -212,25 +191,16 @@ fn enable_isr_service() -> Result<(), EspError> {
     Ok(())
 }
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 type ClosureBox = Box<Box<dyn FnMut()>>;
 
 /// The PinNotifySubscription represents the association between an InputPin and
 /// a registered isr handler.
 /// When the PinNotifySubscription is dropped, the isr handler is unregistered.
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 pub(crate) struct PinNotifySubscription(i32, ClosureBox);
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 impl PinNotifySubscription {
     fn subscribe<P>(pin: &mut P, callback: impl FnMut() + 'static) -> Result<Self, EspError>
     where
@@ -257,10 +227,7 @@ impl PinNotifySubscription {
     }
 }
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 impl Drop for PinNotifySubscription {
     fn drop(self: &mut PinNotifySubscription) {
         esp!(unsafe { esp_idf_sys::gpio_isr_handler_remove(self.0) }).expect("Error unsubscribing");
@@ -268,10 +235,7 @@ impl Drop for PinNotifySubscription {
 }
 
 /// Interrupt types
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 pub enum InterruptType {
     PosEdge,
     NegEdge,
@@ -280,10 +244,7 @@ pub enum InterruptType {
     HighLevel,
 }
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 impl From<InterruptType> for gpio_int_type_t {
     fn from(interrupt_type: InterruptType) -> gpio_int_type_t {
         match interrupt_type {
@@ -342,7 +303,7 @@ macro_rules! impl_base {
                 #[cfg(not(feature = "riscv-ulp-hal"))]
                 let res = {
                     esp!(unsafe { gpio_reset_pin(self.pin()) })?;
-                    #[cfg(any(feature = "std", feature = "alloc"))]
+                    #[cfg(feature = "alloc")]
                     self.disable_interrupt()?;
                     Ok(())
                 };
@@ -445,20 +406,14 @@ macro_rules! impl_base {
                 Ok(())
             }
 
-            #[cfg(all(
-                not(feature = "riscv-ulp-hal"),
-                any(feature = "std", feature = "alloc")
-            ))]
+            #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
             fn enable_interrupt(&mut self) -> Result<(), EspError> {
                 esp!(unsafe { gpio_intr_enable(self.pin()) })?;
 
                 Ok(())
             }
 
-            #[cfg(all(
-                not(feature = "riscv-ulp-hal"),
-                any(feature = "std", feature = "alloc")
-            ))]
+            #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
             fn disable_interrupt(&mut self) -> Result<(), EspError> {
                 esp!(unsafe { gpio_intr_disable(self.pin()) })?;
                 esp!(unsafe { gpio_set_intr_type(self.pin(), gpio_int_type_t_GPIO_INTR_DISABLE) })?;
@@ -467,10 +422,7 @@ macro_rules! impl_base {
                 Ok(())
             }
 
-            #[cfg(all(
-                not(feature = "riscv-ulp-hal"),
-                any(feature = "std", feature = "alloc")
-            ))]
+            #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
             fn set_interrupt_type(
                 &mut self,
                 interrupt_type: InterruptType,
@@ -525,18 +477,12 @@ macro_rules! impl_pull {
     };
 }
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 unsafe fn register_irq_handler(pin_number: usize, p: PinNotifySubscription) {
     chip::IRQ_HANDLERS[pin_number] = Some(p);
 }
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 unsafe fn unregister_irq_handler(pin_number: usize) {
     if chip::IRQ_HANDLERS[pin_number].is_some() {
         chip::IRQ_HANDLERS[pin_number].take();
@@ -583,10 +529,7 @@ macro_rules! impl_input_base {
             }
         }
 
-        #[cfg(all(
-            not(feature = "riscv-ulp-hal"),
-            any(feature = "std", feature = "alloc")
-        ))]
+        #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
         impl $pxi<Input> {
             /// # Safety
             ///
@@ -626,10 +569,7 @@ macro_rules! impl_input_base {
         impl_base!($pxi);
         impl_hal_input_pin!($pxi: Input);
 
-        #[cfg(all(
-            not(feature = "riscv-ulp-hal"),
-            any(feature = "std", feature = "alloc")
-        ))]
+        #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
         impl_hal_input_pin!($pxi: SubscribedInput);
     };
 }
@@ -1036,16 +976,10 @@ where
 
 impl InputPin for GpioPin<Input> {}
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 impl InputPin for GpioPin<SubscribedInput> {}
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 impl SubscribedPin for GpioPin<SubscribedInput> {}
 
 impl OutputPin for GpioPin<Output> {}
@@ -1058,10 +992,7 @@ impl_base!(GpioPin);
 impl_hal_input_pin!(GpioPin: Input);
 impl_hal_input_pin!(GpioPin: InputOutput);
 
-#[cfg(all(
-    not(feature = "riscv-ulp-hal"),
-    any(feature = "std", feature = "alloc")
-))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 impl_hal_input_pin!(GpioPin: SubscribedInput);
 
 impl_hal_output_pin!(GpioPin: InputOutput);
@@ -1079,10 +1010,7 @@ mod chip {
     #[cfg(feature = "riscv-ulp-hal")]
     use crate::riscv_ulp_hal::sys::*;
 
-    #[cfg(all(
-        not(feature = "riscv-ulp-hal"),
-        any(feature = "std", feature = "alloc")
-    ))]
+    #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
     pub(crate) static mut IRQ_HANDLERS: [Option<PinNotifySubscription>; 40] = [
         None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
         None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
@@ -1266,10 +1194,7 @@ mod chip {
 
     use super::*;
 
-    #[cfg(all(
-        not(feature = "riscv-ulp-hal"),
-        any(feature = "std", feature = "alloc")
-    ))]
+    #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
     pub(crate) static mut IRQ_HANDLERS: [Option<PinNotifySubscription>; 49] = [
         None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
         None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
@@ -1517,7 +1442,7 @@ mod chip {
 
     use super::*;
 
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     pub(crate) static mut IRQ_HANDLERS: [Option<PinNotifySubscription>; 22] = [
         None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
         None, None, None, None, None, None, None,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -154,7 +154,8 @@ impl UnsafeCallback {
     }
 }
 
-static ISR_SERVICE_ENABLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static ISR_SERVICE_ENABLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 unsafe extern "C" fn irq_handler(unsafe_callback: *mut esp_idf_sys::c_types::c_void) {
     let mut unsafe_callback = UnsafeCallback::from_ptr(unsafe_callback);
@@ -162,7 +163,13 @@ unsafe extern "C" fn irq_handler(unsafe_callback: *mut esp_idf_sys::c_types::c_v
 }
 
 fn enable_isr_service() -> Result<(), EspError> {
-    if ISR_SERVICE_ENABLED.compare_exchange(false, true, std::sync::atomic::Ordering::SeqCst, std::sync::atomic::Ordering::Relaxed) == Ok(false) {
+    if ISR_SERVICE_ENABLED.compare_exchange(
+        false,
+        true,
+        std::sync::atomic::Ordering::SeqCst,
+        std::sync::atomic::Ordering::Relaxed,
+    ) == Ok(false)
+    {
         if let Err(e) = esp!(unsafe { esp_idf_sys::gpio_install_isr_service(0) }) {
             ISR_SERVICE_ENABLED.store(false, std::sync::atomic::Ordering::SeqCst);
             return Err(e);
@@ -179,8 +186,9 @@ type ClosureBox = Box<Box<dyn for<'a> FnMut()>>;
 pub(crate) struct PinNotifySubscription(i32, ClosureBox);
 
 impl PinNotifySubscription {
-    fn subscribe<P>(pin: &mut P, callback: impl for<'a> FnMut() + 'static) -> Result<Self, EspError> 
-        where P: InputPin + Pin
+    fn subscribe<P>(pin: &mut P, callback: impl for<'a> FnMut() + 'static) -> Result<Self, EspError>
+    where
+        P: InputPin + Pin,
     {
         enable_isr_service()?;
 
@@ -489,7 +497,11 @@ macro_rules! impl_input_base {
         }
 
         impl $pxi<Input> {
-            pub unsafe fn into_subscribed(mut self, callback: impl for<'a> FnMut() + 'static, interrupt_type: InterruptType ) -> Result<$pxi<Subscribed>, EspError> {
+            pub unsafe fn into_subscribed(
+                mut self,
+                callback: impl for<'a> FnMut() + 'static,
+                interrupt_type: InterruptType,
+            ) -> Result<$pxi<Subscribed>, EspError> {
                 self.enable_interrupt()?;
 
                 self.set_interrupt_type(interrupt_type)?;
@@ -553,7 +565,6 @@ macro_rules! impl_input_output {
             MODE: Send,
         {
             pub fn into_input_output(mut self) -> Result<$pxi<InputOutput>, EspError> {
-
                 self.set_input_output()?;
 
                 Ok($pxi { _mode: PhantomData })
@@ -960,10 +971,9 @@ mod chip {
     use crate::riscv_ulp_hal::sys::*;
 
     pub(crate) static mut IRQ_HANDLERS: [Option<PinNotifySubscription>; 40] = [
-        None, None, None, None, None,None, None, None, None, None,
-        None, None, None, None, None,None, None, None, None, None,
-        None, None, None, None, None,None, None, None, None, None,
-        None, None, None, None, None,None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None,
     ];
 
     // NOTE: Gpio26 - Gpio32 are used by SPI0/SPI1 for external PSRAM/SPI Flash and
@@ -1144,10 +1154,10 @@ mod chip {
     use super::*;
 
     pub(crate) static mut IRQ_HANDLERS: [Option<PinNotifySubscription>; 49] = [
-        None, None, None, None, None,None, None, None, None, None, None, None, None,
-        None, None, None, None, None,None, None, None, None, None, None, None,
-        None, None, None, None, None,None, None, None, None, None, None, None,
-        None, None, None, None, None,None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None,
     ];
 
     // NOTE: Gpio26 - Gpio32 (and Gpio33 - Gpio37 if using Octal RAM/Flash) are used
@@ -1391,8 +1401,8 @@ mod chip {
     use super::*;
 
     pub(crate) static mut IRQ_HANDLERS: [Option<PinNotifySubscription>; 22] = [
-        None, None, None, None, None,None, None, None, None, None, None,
-        None, None, None, None, None,None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None,
     ];
 
     // NOTE: Gpio12 - Gpio17 are used by SPI0/SPI1 for external PSRAM/SPI Flash and

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -159,8 +159,8 @@ impl UnsafeCallback {
 }
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "std"))]
-static ISR_SERVICE_ENABLED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+static ISR_SERVICE_ENABLED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "std"))]
 unsafe extern "C" fn irq_handler(unsafe_callback: *mut esp_idf_sys::c_types::c_void) {
@@ -173,12 +173,12 @@ fn enable_isr_service() -> Result<(), EspError> {
     if ISR_SERVICE_ENABLED.compare_exchange(
         false,
         true,
-        std::sync::atomic::Ordering::SeqCst,
-        std::sync::atomic::Ordering::Relaxed,
+        core::sync::atomic::Ordering::SeqCst,
+        core::sync::atomic::Ordering::Relaxed,
     ) == Ok(false)
     {
         if let Err(e) = esp!(unsafe { esp_idf_sys::gpio_install_isr_service(0) }) {
-            ISR_SERVICE_ENABLED.store(false, std::sync::atomic::Ordering::SeqCst);
+            ISR_SERVICE_ENABLED.store(false, core::sync::atomic::Ordering::SeqCst);
             return Err(e);
         }
     }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -131,7 +131,7 @@ pub struct Disabled;
 pub struct Unknown;
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "std"))]
-pub struct Subscribed;
+pub struct SubscribedInput;
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "std"))]
 struct UnsafeCallback(*mut Box<dyn FnMut() + 'static>);
@@ -523,7 +523,7 @@ macro_rules! impl_input_base {
                 mut self,
                 callback: impl FnMut() + 'static,
                 interrupt_type: InterruptType,
-            ) -> Result<$pxi<Subscribed>, EspError> {
+            ) -> Result<$pxi<SubscribedInput>, EspError> {
                 self.enable_interrupt()?;
 
                 self.set_interrupt_type(interrupt_type)?;
@@ -537,7 +537,7 @@ macro_rules! impl_input_base {
         }
 
         #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "std"))]
-        impl $pxi<Subscribed> {
+        impl $pxi<SubscribedInput> {
             pub fn unsubscribe(self) -> Result<$pxi<Input>, EspError> {
                 unsafe { unregister_irq_handler(self.pin() as usize) };
 
@@ -967,10 +967,10 @@ where
 impl InputPin for GpioPin<Input> {}
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "std"))]
-impl InputPin for GpioPin<Subscribed> {}
+impl InputPin for GpioPin<SubscribedInput> {}
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "std"))]
-impl SubscribedPin for GpioPin<Subscribed> {}
+impl SubscribedPin for GpioPin<SubscribedInput> {}
 
 impl OutputPin for GpioPin<Output> {}
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -485,9 +485,7 @@ unsafe fn register_irq_handler(pin_number: usize, p: PinNotifySubscription) {
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 unsafe fn unregister_irq_handler(pin_number: usize) {
-    if chip::IRQ_HANDLERS[pin_number].is_some() {
-        chip::IRQ_HANDLERS[pin_number].take();
-    }
+    chip::IRQ_HANDLERS[pin_number].take();
 }
 
 macro_rules! impl_input_base {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -2,11 +2,11 @@
 
 use core::marker::PhantomData;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 extern crate alloc;
 
-#[cfg(feature = "alloc")]
-use alloc::boxed::Box;
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
+use alloc::{boxed::Box, rc::Rc};
 
 #[cfg(not(feature = "riscv-ulp-hal"))]
 use esp_idf_sys::*;
@@ -165,8 +165,24 @@ impl UnsafeCallback {
 }
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
-static ISR_SERVICE_ENABLED: core::sync::atomic::AtomicBool =
-    core::sync::atomic::AtomicBool::new(false);
+pub struct Service;
+
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
+impl Service {
+    pub fn new(intr_alloc_flags: i32) -> Result<Service, EspError> {
+        let result = esp!(unsafe { gpio_install_isr_service(intr_alloc_flags) });
+        result.map(|_| Service)
+    }
+}
+
+#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
+impl Drop for Service {
+    fn drop(&mut self) {
+        unsafe {
+            gpio_uninstall_isr_service();
+        }
+    }
+}
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 unsafe extern "C" fn irq_handler(unsafe_callback: *mut esp_idf_sys::c_types::c_void) {
@@ -174,40 +190,22 @@ unsafe extern "C" fn irq_handler(unsafe_callback: *mut esp_idf_sys::c_types::c_v
     unsafe_callback.call();
 }
 
-#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
-fn enable_isr_service() -> Result<(), EspError> {
-    if ISR_SERVICE_ENABLED.compare_exchange(
-        false,
-        true,
-        core::sync::atomic::Ordering::SeqCst,
-        core::sync::atomic::Ordering::Relaxed,
-    ) == Ok(false)
-    {
-        if let Err(e) = esp!(unsafe { esp_idf_sys::gpio_install_isr_service(0) }) {
-            ISR_SERVICE_ENABLED.store(false, core::sync::atomic::Ordering::SeqCst);
-            return Err(e);
-        }
-    }
-    Ok(())
-}
-
-#[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
-type ClosureBox = Box<Box<dyn FnMut()>>;
-
 /// The PinNotifySubscription represents the association between an InputPin and
 /// a registered isr handler.
 /// When the PinNotifySubscription is dropped, the isr handler is unregistered.
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
-pub(crate) struct PinNotifySubscription(i32, ClosureBox);
+pub(crate) struct PinNotifySubscription(Rc<Service>, i32, Box<Box<dyn FnMut()>>);
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 impl PinNotifySubscription {
-    fn subscribe<P>(pin: &mut P, callback: impl FnMut() + 'static) -> Result<Self, EspError>
+    fn subscribe<P>(
+        service: Rc<Service>,
+        pin: &mut P,
+        callback: impl FnMut() + 'static,
+    ) -> Result<Self, EspError>
     where
         P: InputPin + Pin,
     {
-        enable_isr_service()?;
-
         let pin_number: i32 = pin.pin();
 
         let callback: Box<dyn FnMut() + 'static> = Box::new(callback);
@@ -223,14 +221,14 @@ impl PinNotifySubscription {
             )
         })?;
 
-        Ok(Self(pin_number, callback))
+        Ok(Self(service, pin_number, callback))
     }
 }
 
 #[cfg(all(not(feature = "riscv-ulp-hal"), feature = "alloc"))]
 impl Drop for PinNotifySubscription {
     fn drop(self: &mut PinNotifySubscription) {
-        esp!(unsafe { esp_idf_sys::gpio_isr_handler_remove(self.0) }).expect("Error unsubscribing");
+        esp!(unsafe { esp_idf_sys::gpio_isr_handler_remove(self.1) }).expect("Error unsubscribing");
     }
 }
 
@@ -540,6 +538,7 @@ macro_rules! impl_input_base {
             /// interrupt handler. So you should take care of what is done in it.
             pub unsafe fn into_subscribed(
                 mut self,
+                service: &Rc<Service>,
                 callback: impl FnMut() + 'static,
                 interrupt_type: InterruptType,
             ) -> Result<$pxi<SubscribedInput>, EspError> {
@@ -547,7 +546,8 @@ macro_rules! impl_input_base {
 
                 self.set_interrupt_type(interrupt_type)?;
 
-                let callback = PinNotifySubscription::subscribe(&mut self, callback)?;
+                let callback =
+                    PinNotifySubscription::subscribe(Rc::clone(service), &mut self, callback)?;
 
                 register_irq_handler(self.pin() as usize, callback);
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -497,6 +497,10 @@ macro_rules! impl_input_base {
         }
 
         impl $pxi<Input> {
+            /// # Safety
+            ///
+            /// The callback passed to this method is executed in the context of an
+            /// interrupt handler. So you should take care of what is done in it.
             pub unsafe fn into_subscribed(
                 mut self,
                 callback: impl for<'a> FnMut() + 'static,


### PR DESCRIPTION
Hi !

Here is a first proposal for a GPIO interrupt handler subscription.

1. I chose to implement a new state rather than subtyping `Input` because I am not sure that a Pin used for interrupt would be used for something else.
2. I did not implemented it for `InputOutput` because when testing interrupt on Pin configured this way I was not able to get any interrupt, so I am not sure that it's possible with `esp-idf`.
3. I keep the PinNotifySubscription in a static mut array `IRQ_HANDLERS` and did not guard access to it with a Mutex because I guess that needing to own the pin makes it thread safe as long as we respect the current state.
4. It's not possible to register a new handler if you did not unsubscribed the older before.
5. I need to init the array with the full value list, because using [None; <PIN_COUNT>] requires that PinNotifySubscription implements Copy and that's not what we want.
6. I don't really like the interactions between the gpio mod and the chip mod regarding the IRQ_HANDLERS array, but I did not know to handle it better.
7. I was able to test it on an Esp32 with [this project](https://github.com/pyaillet/esp32-isr/blob/use-patched-eih/src/main.rs). I do not own other models to test against them :\

As usual, any comments and feedbacks are welcomed :)