### PR TITLE
Pull out shared bus

### DIFF
--- a/examples/spi_loopback.rs
+++ b/examples/spi_loopback.rs
@@ -32,17 +32,16 @@ fn main() -> anyhow::Result<()> {
     let cs = peripherals.pins.gpio10;
 
     println!("Starting SPI loopback test");
-    let config = <spi::config::Config as Default>::default().baudrate(26.MHz().into());
-    let mut spi = spi::Master::<spi::SPI2, _, _, _, _>::new(
+    let bus = spi::Bus::<spi::SPI2, _, _, _>::new(
         spi,
         spi::Pins {
             sclk,
             sdo: miso,
             sdi: Some(mosi),
-            cs: Some(cs),
         },
-        config,
     )?;
+    let config = <spi::config::Config as Default>::default().baudrate(26.MHz().into());
+    let mut spi = spi::Master::new(&bus, Some(cs), config)?;
 
     let mut read = [0u8; 4];
     let write = [0xde, 0xad, 0xbe, 0xef];

--- a/examples/spi_loopback.rs
+++ b/examples/spi_loopback.rs
@@ -11,6 +11,7 @@
 //! This example transfers data via SPI.
 //! Connect MISO and MOSI pins to see the outgoing data is read as incoming data.
 
+use std::rc::Rc;
 use std::thread;
 use std::time::Duration;
 
@@ -32,7 +33,7 @@ fn main() -> anyhow::Result<()> {
     let cs = peripherals.pins.gpio10;
 
     println!("Starting SPI loopback test");
-    let bus = spi::Bus::<spi::SPI2, _, _, _>::new(
+    let bus = spi::RWBus::<spi::SPI2, _, _, _>::new(
         spi,
         spi::Pins {
             sclk,

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -19,9 +19,7 @@
 //! - DMA
 //! - Slave
 
-use core::borrow::Borrow;
 use core::cmp::{max, min};
-use core::ops::Deref;
 use core::ptr;
 
 use crate::delay::portMAX_DELAY;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -20,10 +20,10 @@
 //! - Multiple CS pins
 //! - Slave
 
-use core::cmp::{max, min};
-use core::ptr;
 use core::borrow::Borrow;
+use core::cmp::{max, min};
 use core::marker::PhantomData;
+use core::ptr;
 
 use crate::delay::portMAX_DELAY;
 use crate::gpio::{self, InputPin, OutputPin};

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -22,8 +22,8 @@
 
 use core::cmp::{max, min};
 use core::ptr;
-use std::borrow::Borrow;
-use std::marker::PhantomData;
+use core::borrow::Borrow;
+use core::marker::PhantomData;
 
 use crate::delay::portMAX_DELAY;
 use crate::gpio::{self, InputPin, OutputPin};


### PR DESCRIPTION
This allows users to create multiple devices on one bus.

The current SPI interface allows one to create a single `Master` struct which represents the spi bus and the device.
This prevents one from communicating with multiple SPI devices on the same bus. In my case, I have an E-Ink display and an SD card on the same bus and I'm only able to use one at a time.

This PR pulls out the spi bus from the `Master` struct into a `Bus` struct, which allows one to create multiple `Master`s on the same bus.

The one thing I wasn't too sure about is whether `Bus` should be a struct or trait. I've got with struct for the moment. I don't really see the need for a trait atm.