### PR TITLE
Improve I2C errors

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -284,9 +284,11 @@ where
         command_link
             .master_write_byte((addr << 1) | (i2c_rw_t_I2C_MASTER_READ as u8), true)
             .map_err(I2cError::other)?;
-        command_link
-            .master_read(buffer, AckType::LastNack)
-            .map_err(I2cError::other)?;
+        if !buffer.is_empty() {
+            command_link
+                .master_read(buffer, AckType::LastNack)
+                .map_err(I2cError::other)?;
+        }
         command_link.master_stop().map_err(I2cError::other)?;
 
         esp!(unsafe { i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout) })
@@ -302,9 +304,11 @@ where
             .master_write_byte((addr << 1) | (i2c_rw_t_I2C_MASTER_WRITE as u8), true)
             .map_err(I2cError::other)?;
 
-        command_link
-            .master_write(bytes, true)
-            .map_err(I2cError::other)?;
+        if !bytes.is_empty() {
+            command_link
+                .master_write(bytes, true)
+                .map_err(I2cError::other)?;
+        }
         command_link.master_stop().map_err(I2cError::other)?;
         esp!(unsafe { i2c_master_cmd_begin(I2C::port(), command_link.0, self.timeout) })
             .map_err(I2cError::other)
@@ -317,17 +321,21 @@ where
         command_link
             .master_write_byte((addr << 1) | (i2c_rw_t_I2C_MASTER_WRITE as u8), true)
             .map_err(I2cError::other)?;
-        command_link
-            .master_write(bytes, true)
-            .map_err(I2cError::other)?;
+        if !bytes.is_empty() {
+            command_link
+                .master_write(bytes, true)
+                .map_err(I2cError::other)?;
+        }
 
         command_link.master_start().map_err(I2cError::other)?;
         command_link
             .master_write_byte((addr << 1) | (i2c_rw_t_I2C_MASTER_READ as u8), true)
             .map_err(I2cError::other)?;
-        command_link
-            .master_read(buffer, AckType::LastNack)
-            .map_err(I2cError::other)?;
+        if !buffer.is_empty() {
+            command_link
+                .master_read(buffer, AckType::LastNack)
+                .map_err(I2cError::other)?;
+        }
 
         command_link.master_stop().map_err(I2cError::other)?;
 


### PR DESCRIPTION
The main motivation for this PR is to allow me to implement ack polling.

I've split it up into three commits for easy review.
1. Just small refactor to use safe `CommandLink` methods added in #59 .
2. Skip command if buffer is empty. The esp-idf driver complains if you call `i2c_master_write` and `i2c_master_read` with an empty buffer.
3. When the command_link is submitted and `ESP_FAIL` is returned, it means the slave didn't ack. I've simply made a change here to make this more visible in a generic driver.

I'm working with an EEPROM, where after sending a write command to it, it stops responding to it's slave address until it's done writing. To check if the device is accepting commands again, I have to call `Master::write(addr, &[])` until it doesn't fail with `ErrorKind::NoAcknowledge`.
At the moment I can't do this with esp-idf-hal because it returns `ErrorKind::Other` for all errors and it returns an error when I call `Master::write` with an empty buffer. This PR fixes this.