### PR TITLE
Migrate to e-hal 1.0.0-alpha.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ experimental = []
 [dependencies]
 nb = "0.1.2"
 mutex-trait = { version = "0.2", optional = true, default-features = false }
-embedded-hal = "=1.0.0-alpha.7"
+embedded-hal = "=1.0.0-alpha.8"
 embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"] }
 embedded-svc = { version = "0.19", optional = true, default-features = false }
 esp-idf-sys = { version = "0.31", optional = true, default-features = false, features = ["native"] }

--- a/examples/spi_loopback.rs
+++ b/examples/spi_loopback.rs
@@ -14,7 +14,7 @@
 use std::thread;
 use std::time::Duration;
 
-use embedded_hal_0_2::blocking::spi::Transfer;
+use embedded_hal::spi::blocking::SpiDevice;
 
 use esp_idf_hal::peripherals::Peripherals;
 use esp_idf_hal::prelude::*;
@@ -50,8 +50,7 @@ fn main() -> anyhow::Result<()> {
     loop {
         // we are using thread::sleep here to make sure the watchdog isn't triggered
         thread::sleep(Duration::from_millis(500));
-        read.copy_from_slice(&write);
-        spi.transfer(&mut read)?;
+        spi.transfer(&mut read, &write)?;
         println!("Wrote {:x?}, read {:x?}", write, read);
     }
 }

--- a/examples/spi_loopback.rs
+++ b/examples/spi_loopback.rs
@@ -14,7 +14,7 @@
 use std::thread;
 use std::time::Duration;
 
-use embedded_hal::spi::blocking::Transfer;
+use embedded_hal_0_2::blocking::spi::Transfer;
 
 use esp_idf_hal::peripherals::Peripherals;
 use esp_idf_hal::prelude::*;
@@ -50,7 +50,8 @@ fn main() -> anyhow::Result<()> {
     loop {
         // we are using thread::sleep here to make sure the watchdog isn't triggered
         thread::sleep(Duration::from_millis(500));
-        spi.transfer(&mut read, &write)?;
+        read.copy_from_slice(&write);
+        spi.transfer(&mut read)?;
         println!("Wrote {:x?}, read {:x?}", write, read);
     }
 }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -311,35 +311,8 @@ where
     }
 }
 
-#[cfg(not(feature = "riscv-ulp-hal"))]
-impl<ADC, AN, PIN> embedded_hal::adc::nb::OneShot<AN, u16, PIN> for PoweredAdc<ADC>
-where
-    ADC: Adc,
-    AN: Analog<ADC>,
-    PIN: embedded_hal::adc::nb::Channel<AN, ID = u8>,
-{
-    type Error = EspError;
-
-    fn read(&mut self, pin: &mut PIN) -> nb::Result<u16, Self::Error> {
-        self.read(
-            ADC::unit(),
-            pin.channel() as adc_channel_t,
-            AN::attenuation(),
-        )
-    }
-}
-
 #[cfg(all(esp32, not(feature = "riscv-ulp-hal")))]
 impl embedded_hal_0_2::adc::OneShot<ADC1, u16, hall::HallSensor> for PoweredAdc<ADC1> {
-    type Error = EspError;
-
-    fn read(&mut self, _hall_sensor: &mut hall::HallSensor) -> nb::Result<u16, Self::Error> {
-        self.read_hall()
-    }
-}
-
-#[cfg(all(esp32, not(feature = "riscv-ulp-hal")))]
-impl embedded_hal::adc::nb::OneShot<ADC1, u16, hall::HallSensor> for PoweredAdc<ADC1> {
     type Error = EspError;
 
     fn read(&mut self, _hall_sensor: &mut hall::HallSensor) -> nb::Result<u16, Self::Error> {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -736,17 +736,6 @@ macro_rules! impl_adc {
                 $adc
             }
         }
-
-        impl<AN> embedded_hal::adc::nb::Channel<AN> for $pxi<AN>
-        where
-            AN: adc::Analog<adc::ADC1> + Send,
-        {
-            type ID = u8;
-
-            fn channel(&self) -> Self::ID {
-                $adc
-            }
-        }
     };
 
     ($pxi:ident: $pin:expr, ADC2: $adc:expr) => {
@@ -812,17 +801,6 @@ macro_rules! impl_adc {
             type ID = u8;
 
             fn channel() -> Self::ID {
-                $adc
-            }
-        }
-
-        impl<AN> embedded_hal::adc::nb::Channel<AN> for $pxi<AN>
-        where
-            AN: adc::Analog<adc::ADC2> + Send,
-        {
-            type ID = u8;
-
-            fn channel(&self) -> Self::ID {
                 $adc
             }
         }

--- a/src/hall.rs
+++ b/src/hall.rs
@@ -22,11 +22,3 @@ impl embedded_hal_0_2::adc::Channel<adc::ADC1> for HallSensor {
         ()
     }
 }
-
-impl embedded_hal::adc::nb::Channel<adc::ADC1> for HallSensor {
-    type ID = ();
-
-    fn channel(&self) -> Self::ID {
-        ()
-    }
-}

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -470,12 +470,6 @@ impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: O
 }
 
 impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>
-    embedded_hal::spi::ErrorType for Master<SPI, SCLK, SDO, SDI, CS>
-{
-    type Error = SpiError;
-}
-
-impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>
     embedded_hal_0_2::blocking::spi::Transfer<u8> for Master<SPI, SCLK, SDO, SDI, CS>
 {
     type Error = SpiError;
@@ -484,32 +478,6 @@ impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: O
         self.transfer_inplace_internal(words, true)?;
 
         Ok(words)
-    }
-}
-
-impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>
-    embedded_hal::spi::blocking::TransferInplace<u8> for Master<SPI, SCLK, SDO, SDI, CS>
-{
-    fn transfer_inplace(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
-        self.transfer_inplace_internal(words, true)?;
-
-        Ok(())
-    }
-}
-
-impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>
-    embedded_hal::spi::blocking::Transfer<u8> for Master<SPI, SCLK, SDO, SDI, CS>
-{
-    fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
-        self.transfer_internal(read, write, true)
-    }
-}
-
-impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>
-    embedded_hal::spi::blocking::Read<u8> for Master<SPI, SCLK, SDO, SDI, CS>
-{
-    fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
-        self.transfer_internal(words, &[], true)
     }
 }
 
@@ -524,29 +492,10 @@ impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: O
 }
 
 impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>
-    embedded_hal::spi::blocking::Write<u8> for Master<SPI, SCLK, SDO, SDI, CS>
-{
-    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-        self.transfer_internal(&mut [], words, true)
-    }
-}
-
-impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>
     embedded_hal_0_2::blocking::spi::WriteIter<u8> for Master<SPI, SCLK, SDO, SDI, CS>
 {
     type Error = SpiError;
 
-    fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
-    where
-        WI: IntoIterator<Item = u8>,
-    {
-        self.write_iter_internal(words)
-    }
-}
-
-impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>
-    embedded_hal::spi::blocking::WriteIter<u8> for Master<SPI, SCLK, SDO, SDI, CS>
-{
     fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
     where
         WI: IntoIterator<Item = u8>,
@@ -572,36 +521,6 @@ impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: O
                     self.transfer_internal(&mut [], write, false)?
                 }
                 embedded_hal_0_2::blocking::spi::Operation::Transfer(words) => {
-                    self.transfer_inplace_internal(words, false)?
-                }
-            }
-        }
-
-        Ok(())
-    }
-}
-
-impl<SPI: Spi, SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>
-    embedded_hal::spi::blocking::Transactional<u8> for Master<SPI, SCLK, SDO, SDI, CS>
-{
-    fn exec<'a>(
-        &mut self,
-        operations: &mut [embedded_hal::spi::blocking::Operation<'a, u8>],
-    ) -> Result<(), Self::Error> {
-        let _lock = self.lock_bus()?;
-
-        for operation in operations {
-            match operation {
-                embedded_hal::spi::blocking::Operation::Read(read) => {
-                    self.transfer_internal(read, &[], false)?
-                }
-                embedded_hal::spi::blocking::Operation::Write(write) => {
-                    self.transfer_internal(&mut [], write, false)?
-                }
-                embedded_hal::spi::blocking::Operation::Transfer(read, write) => {
-                    self.transfer_internal(read, write, false)?
-                }
-                embedded_hal::spi::blocking::Operation::TransferInplace(words) => {
                     self.transfer_inplace_internal(words, false)?
                 }
             }


### PR DESCRIPTION
See https://github.com/rust-embedded/embedded-hal/releases/tag/v1.0.0-alpha.8

Some adc traits were removed.

GitHub diff looks a bit weird so maybe use the Side by side viewer.

In the meantime, I'm going to test this on my SPI device.