### PR TITLE
serial: set rx_flow_ctrl_thresh to 122

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -334,6 +334,7 @@ impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin>
             parity: config.parity.into(),
             stop_bits: config.stop_bits.into(),
             flow_ctrl: config.flow_control.into(),
+            rx_flow_ctrl_thresh: 122,
             ..Default::default()
         };
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -204,6 +204,7 @@ pub mod config {
         pub parity: Parity,
         pub stop_bits: StopBits,
         pub flow_control: FlowControl,
+        pub flow_control_rts_threshold: u8,
     }
 
     impl Config {
@@ -252,6 +253,15 @@ pub mod config {
             self.flow_control = flow_control;
             self
         }
+
+        #[must_use]
+        /// This setting only has effect if flow control is enabled.
+        /// It determines how many bytes must be received before `RTS` line is asserted.
+        /// Notice that count starts from `0` which means that `RTS` is asserted after every received byte.
+        pub fn flow_control_rts_threshold(mut self, flow_control_rts_threshold: u8) -> Self {
+            self.flow_control_rts_threshold = flow_control_rts_threshold;
+            self
+        }
     }
 
     impl Default for Config {
@@ -262,6 +272,7 @@ pub mod config {
                 parity: Parity::ParityNone,
                 stop_bits: StopBits::STOP1,
                 flow_control: FlowControl::None,
+                flow_control_rts_threshold: 122,
             }
         }
     }
@@ -334,7 +345,7 @@ impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin>
             parity: config.parity.into(),
             stop_bits: config.stop_bits.into(),
             flow_ctrl: config.flow_control.into(),
-            rx_flow_ctrl_thresh: 122,
+            rx_flow_ctrl_thresh: config.flow_control_rts_threshold,
             ..Default::default()
         };
 


### PR DESCRIPTION
Here
```rust
let uart_config = uart_config_t {
    baud_rate: config.baudrate.0 as i32,
    data_bits: config.data_bits.into(),
    parity: config.parity.into(),
    stop_bits: config.stop_bits.into(),
    flow_ctrl: config.flow_control.into(),
    ..Default::default()
};
```

..Default::default() sets `rx_flow_ctrl_thresh` to `0` which is not desirable, because then `RTS` line is asserted after every received byte. ESP32 has ~128 byte RX FIFO, so it makes sense to be around this large. Most of the ESP32 [examples](https://docs.espressif.com/projects/esp-idf/en/release-v3.3/api-reference/peripherals/uart.html) are using `122` for `rx_flow_ctrl_thresh`.

This is how it looks like when it is `0` (RTS is asserted for ~1ms after every received byte):
![Screen Shot 2022-05-12 at 11 26 23](https://user-images.githubusercontent.com/809232/168082040-36df1381-6445-40ba-b8ba-969165ae10c4.jpg)

With `122` it looks much better:
![Screen Shot 2022-05-12 at 16 10 27](https://user-images.githubusercontent.com/809232/168082391-e6d2083e-aec7-4609-b81d-551f54b60c05.jpg)