### PR TITLE
i2c: fix double InputPin typo

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -15,7 +15,7 @@ pub struct MasterPins<SDA: OutputPin + InputPin, SCL: OutputPin + InputPin> {
     pub scl: SCL,
 }
 
-pub struct SlavePins<SDA: OutputPin + InputPin, SCL: InputPin + InputPin> {
+pub struct SlavePins<SDA: OutputPin + InputPin, SCL: OutputPin + InputPin> {
     pub sda: SDA,
     pub scl: SCL,
 }


### PR DESCRIPTION
Of course I notice this right after you merge it...