### PR TITLE
serial: Add support for interrupts and variable RX/TX buffer size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ embedded-svc = { version = "0.22.0", optional = true, default-features = false }
 esp-idf-sys = { version = "0.31.4", optional = true, default-features = false, features = ["native"] }
 critical-section = { version = "0.2.5", optional = true, features = ["custom-impl"] }
 embassy = { version = "0", optional = true }
+bitmask-enum = "2.0.0"
 # The real version is this one and it needs to be patched into the binary crate:
 #embassy = { version = "0.1", git = "https://github.com/embassy-rs/embassy", optional = true, features = ["executor-agnostic"] }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -33,7 +33,7 @@
 //!     writeln!(serial, "{:}", format!("count {:}", i)).unwrap();
 //! }
 //! ```
-//! 
+//!
 //! Interrupt-driven usage:
 //! ```
 //! use std::fmt::Write;
@@ -63,7 +63,7 @@
 //!             None => continue,
 //!             Some(e) => e
 //!         };
-//! 
+//!
 //!         match event.get_type() {
 //!             Some(Event::Data) => loop {
 //!                 match serial.read() {
@@ -83,7 +83,7 @@
 //!         };
 //!     }
 //! });
-//! 
+//!
 //! loop {
 //!     thread::sleep(Duration::from_secs(1));
 //! }
@@ -100,8 +100,8 @@ use core::ptr;
 use crate::gpio::*;
 use crate::units::*;
 
-use esp_idf_sys::*;
 use esp_idf_sys::c_types::c_void;
+use esp_idf_sys::*;
 
 use bitmask_enum::bitmask;
 
@@ -154,7 +154,7 @@ pub enum Interrupt {
 /// UART interrupt configuration
 pub mod isr_config {
     use crate::serial::Interrupt;
-    
+
     use esp_idf_sys::uart_intr_config_t;
 
     /// UART interrupt configuration
@@ -460,8 +460,8 @@ pub mod config {
                 stop_bits: StopBits::STOP1,
                 flow_control: FlowControl::None,
                 flow_control_rts_threshold: 122,
-                rx_buffer_size: UART_FIFO_SIZE*2,
-                tx_buffer_size: UART_FIFO_SIZE*2,
+                rx_buffer_size: UART_FIFO_SIZE * 2,
+                tx_buffer_size: UART_FIFO_SIZE * 2,
                 event_queue_size: 0,
             }
         }
@@ -774,12 +774,15 @@ impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin>
                     1 => Some(EventStruct { 0: event }),
                     _ => None,
                 }
-            },
+            }
             None => None,
         }
     }
 
-    pub fn configure_interrupt(&mut self, config: isr_config::IsrConfig) -> Result<&mut Self, esp_idf_sys::EspError> {
+    pub fn configure_interrupt(
+        &mut self,
+        config: isr_config::IsrConfig,
+    ) -> Result<&mut Self, esp_idf_sys::EspError> {
         let uart_config: uart_intr_config_t = config.into();
         esp_result!(
             unsafe { uart_intr_config(UART::port(), &uart_config) },
@@ -806,7 +809,12 @@ impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin>
     /// Starts listening for RX interrupt events
     pub fn listen_rx(&mut self) -> Result<&mut Self, esp_idf_sys::EspError> {
         esp_result!(
-            unsafe { uart_enable_intr_mask(UART::port(), (Interrupt::RxfifoTout | Interrupt::RxfifoFull).bits()) },
+            unsafe {
+                uart_enable_intr_mask(
+                    UART::port(),
+                    (Interrupt::RxfifoTout | Interrupt::RxfifoFull).bits(),
+                )
+            },
             self
         )
     }
@@ -814,7 +822,12 @@ impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin>
     /// Stop listening for RX interrupt events
     pub fn unlisten_rx(&mut self) -> Result<&mut Self, esp_idf_sys::EspError> {
         esp_result!(
-            unsafe { uart_disable_intr_mask(UART::port(), (Interrupt::RxfifoTout | Interrupt::RxfifoFull).bits()) },
+            unsafe {
+                uart_disable_intr_mask(
+                    UART::port(),
+                    (Interrupt::RxfifoTout | Interrupt::RxfifoFull).bits(),
+                )
+            },
             self
         )
     }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -559,7 +559,7 @@ pub enum Event {
     /// Pattern detected
     /// Triggered for `Interrupt::CmdCharDet`
     PatternDet,
-    /// Supposedely `UART_EVENT_MAX`, seems to be used for RS285 errors in `components/driver/uart.c:uart_rx_intr_handler_default`
+    /// Supposedely `UART_EVENT_MAX`, seems to be used for RS485 errors in `components/driver/uart.c:uart_rx_intr_handler_default`
     /// Triggered for `Interrupt::Rs485ParityErr`, `Interrupt::Rs485FrmErr`, `Interrupt::Rs485Clash`, `Interrupt::TxDone`
     Invalid,
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -770,7 +770,8 @@ impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin>
     pub fn write_bytes(&mut self, buf: &[u8]) -> nb::Result<usize, SerialError> {
         self.tx.write_bytes(buf)
     }
-    
+
+    /// Block current task until an event occurs
     pub fn wait_for_event(&self) -> Option<EventStruct> {
         match &self.event_handle {
             Some(event_handle) => event_handle.wait_for_event(),
@@ -778,6 +779,7 @@ impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin>
         }
     }
 
+    /// Configure interruptions
     pub fn configure_interrupt(
         &mut self,
         config: isr_config::IsrConfig,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -677,7 +677,7 @@ impl<UART: Uart, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin>
                 0,
             )
         })?;
-        let event_handle = match handle.is_null() {
+        let event_handle = match !handle.is_null() {
             true => Some(EventQueue::new(handle)),
             false => None,
         };


### PR DESCRIPTION
This PR adds support for interrupt-driven workflow for UARTs and adjusting RX/TX buffer size from the user facing config struct.

This allows notably to create tasks that can wait indefinitely for RX data without having to poll continuously, and a first step towards DMA support.

This is my first contribution on `esp-idf-hal`, so a thorough review would be welcome.
One particular point of attention is for `EventStruct` which manually implements `Send`. I'm not really sure if that's the good way to wrap the event handle allocated from IDF, and maybe wrapping it up in a mutex could be safer there.