### PR TITLE
Add CI for ESP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           crate: ldproxy
           version: latest
+        if: matrix.target == 'riscv32imc-esp-espidf'
 
       - name: Build | Examples
         run: export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo build --examples --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: export ESP_IDF_VERSION=release/v4.4; export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo build --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
 
       - name: Build | RISCV-ULP-HAL feature
-        run: cargo build --features riscv-ulp-hal --no-default-features --target riscv32imc-unknown-none-elf -Zbuild-std=core,panic_abort -Zbuild-std-features=panic_immediate_abort
+        run: export ESP_IDF_VERSION=release/v4.4; cargo build --features riscv-ulp-hal --no-default-features --target riscv32imc-unknown-none-elf -Zbuild-std=core,panic_abort -Zbuild-std-features=panic_immediate_abort
 
       - name: Build | Compile Native ESP-IDF V4.4 no_std
         run: export ESP_IDF_VERSION=release/v4.4; export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo build --features esp-idf-sys/native --no-default-features --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
@@ -67,4 +67,4 @@ jobs:
         if: matrix.target == 'riscv32imc-esp-espidf'
 
       - name: Build | Examples
-        run: export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo build --examples --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+        run: export ESP_IDF_VERSION=release/v4.4; export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo build --examples --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,32 +15,55 @@ jobs:
   compile:
     name: Compile
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - riscv32imc-esp-espidf
+          - xtensa-esp32-espidf
+          - xtensa-esp32s2-espidf
+          - xtensa-esp32s3-espidf
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v2
+
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.rust_toolchain }}
           components: rustfmt, clippy
+          default: true
+        if: matrix.target == 'riscv32imc-esp-espidf'
+
       - name: Setup | Std
         run: rustup component add rust-src --toolchain ${{ env.rust_toolchain }}-x86_64-unknown-linux-gnu
-      - name: Setup | Default to nightly
-        run: rustup default ${{ env.rust_toolchain }}
+        if: matrix.target == 'riscv32imc-esp-espidf'
+
+      - name: Install Rust for Xtensa
+        uses: esp-rs/xtensa-toolchain@v1.2.0
+        with:
+          default: true
+        if: matrix.target != 'riscv32imc-esp-espidf'
+
       - name: Build | Fmt Check
         run: cargo fmt -- --check
+
       - name: Build | Clippy
-        run: export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo clippy --no-deps --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort -- -Dwarnings 
+        run: export ESP_IDF_VERSION=release/v4.4; export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo clippy --no-deps --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort -- -Dwarnings
+
       - name: Build | Compile
-        run: export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo build --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+        run: export ESP_IDF_VERSION=release/v4.4; export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo build --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+
       - name: Build | RISCV-ULP-HAL feature
         run: cargo build --features riscv-ulp-hal --no-default-features --target riscv32imc-unknown-none-elf -Zbuild-std=core,panic_abort -Zbuild-std-features=panic_immediate_abort
+
       - name: Build | Compile Native ESP-IDF V4.4 no_std
-        run: export ESP_IDF_VERSION=release/v4.4; export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo build --features esp-idf-sys/native --no-default-features --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+        run: export ESP_IDF_VERSION=release/v4.4; export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo build --features esp-idf-sys/native --no-default-features --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+
       - name: Setup | ldproxy
         uses: actions-rs/install@v0.1
         with:
           crate: ldproxy
           version: latest
+
       - name: Build | Examples
-        run: export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo build --examples --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+        run: export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo build --examples --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -10,16 +10,37 @@ jobs:
   publishdryrun:
     name: Publish Dry Run
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - riscv32imc-esp-espidf
+          - xtensa-esp32-espidf
+          - xtensa-esp32s2-espidf
+          - xtensa-esp32s3-espidf
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v2
+
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.rust_toolchain }}
+          components: rustfmt, clippy
+          default: true
+        if: matrix.target == 'riscv32imc-esp-espidf'
+
       - name: Setup | Std
         run: rustup component add rust-src --toolchain ${{ env.rust_toolchain }}-x86_64-unknown-linux-gnu
-      - name: Setup | Default to nightly
-        run: rustup default ${{ env.rust_toolchain }}
+        if: matrix.target == 'riscv32imc-esp-espidf'
+
+      - name: Install Rust for Xtensa
+        uses: esp-rs/xtensa-toolchain@v1.2.0
+        with:
+          default: true
+        if: matrix.target != 'riscv32imc-esp-espidf'
+
+      - name: Setup | Std
+        run: rustup component add rust-src --toolchain ${{ env.rust_toolchain }}-x86_64-unknown-linux-gnu
+
       - name: Build | Publish Dry Run
-        run: export ESP_IDF_TOOLS_INSTALL_DIR=out; export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo publish --dry-run --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+        run: export ESP_IDF_TOOLS_INSTALL_DIR=out; export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo publish --dry-run --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,25 +10,45 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - riscv32imc-esp-espidf
+          - xtensa-esp32-espidf
+          - xtensa-esp32s2-espidf
+          - xtensa-esp32s3-espidf
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v2
+
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.rust_toolchain }}
+          default: true
+        if: matrix.target == 'riscv32imc-esp-espidf'
+
       - name: Setup | Std
         run: rustup component add rust-src --toolchain ${{ env.rust_toolchain }}-x86_64-unknown-linux-gnu
-      - name: Setup | Default to nightly
-        run: rustup default ${{ env.rust_toolchain }}
+        if: matrix.target == 'riscv32imc-esp-espidf'
+
+      - name: Install Rust for Xtensa
+        uses: esp-rs/xtensa-toolchain@v1.2.0
+        with:
+          default: true
+        if: matrix.target != 'riscv32imc-esp-espidf'
+
       - name: Login
         run: cargo login ${{ secrets.crates_io_token }}
+
       - name: Build | Publish
-        run: export ESP_IDF_TOOLS_INSTALL_DIR=out; export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo publish --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+        run: export ESP_IDF_TOOLS_INSTALL_DIR=out; export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo publish --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+
       - name: Build Documentation
-        run: cargo doc --features esp-idf-sys/native --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort; echo "<meta http-equiv=\"refresh\" content=\"0; url=esp_idf_hal\">" > target/riscv32imc-esp-espidf/doc/index.html; mv target/riscv32imc-esp-espidf/doc ./docs
+        run: cargo doc --features esp-idf-sys/native --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort; echo "<meta http-equiv=\"refresh\" content=\"0; url=esp_idf_hal\">" > target/riscv32imc-esp-espidf/doc/index.html; mv target/riscv32imc-esp-espidf/doc ./docs
+
       - name: Deploy Documentation
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ (github.ref == 'refs/heads/master') && (matrix.target == 'riscv32imc-esp-espidf') }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/hall.rs
+++ b/src/hall.rs
@@ -18,7 +18,5 @@ unsafe impl Send for HallSensor {}
 impl embedded_hal_0_2::adc::Channel<adc::ADC1> for HallSensor {
     type ID = ();
 
-    fn channel() -> Self::ID {
-        ()
-    }
+    fn channel() -> Self::ID {}
 }


### PR DESCRIPTION
From what I understand CI is currently only run for the ESP32-C3. This PR adds a github workflow for the ESP32. I believe this could be useful since some code is not active when building for the ESP32-C3.

Suggestions are welcome. [Here](https://github.com/usbalbin/esp-idf-hal/runs/7157420054?check_suite_focus=true) is the result of the run.