### PR TITLE
Make RMT examples compile for ESP32 and ESP32-C2

### DIFF
--- a/examples/rmt_morse_code.rs
+++ b/examples/rmt_morse_code.rs
@@ -37,7 +37,7 @@ fn main() -> anyhow::Result<()> {
         .frequency(611.Hz());
     let mut config = TransmitConfig::new()
         .carrier(Some(carrier))
-        .looping(Loop::Count(100))
+        .looping(Loop::Endless)
         .clock_divider(255);
 
     let tx = send_morse_code(&config, led, channel, "HELLO ")?;

--- a/examples/rmt_musical_buzzer.rs
+++ b/examples/rmt_musical_buzzer.rs
@@ -19,7 +19,7 @@ fn main() -> anyhow::Result<()> {
     let peripherals = Peripherals::take().unwrap();
     let led = peripherals.pins.gpio17.into_output()?;
     let channel = peripherals.rmt.channel0;
-    let config = TransmitConfig::new().looping(Loop::Count(1024));
+    let config = TransmitConfig::new().looping(Loop::Endless);
     let mut tx = Transmit::new(led, channel, &config)?;
 
     loop {


### PR DESCRIPTION
Noticed during #96 that some of the examples does not compile for ESP32 and ESP32-C2. Not 100% sure if these changes will have bad consequences