### PR TITLE
FreeRtos.delay_ms_internal: use saturating_add for round-up-divide calc

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -133,7 +133,7 @@ impl FreeRtos {
 
     fn delay_ms_internal(&mut self, ms: u32) {
         // divide by tick length, rounding up
-        let ticks = (ms + portTICK_PERIOD_MS - 1) / portTICK_PERIOD_MS;
+        let ticks = ms.saturating_add(portTICK_PERIOD_MS - 1) / portTICK_PERIOD_MS;
 
         unsafe {
             vTaskDelay(ticks);


### PR DESCRIPTION
This prevents a panic when trying to "infinite"-delay with a value of `u32::MAX`. (yes, this does happen in real life here and there.)