### PR TITLE
V5 ESP32 Hall Sensor unsupported

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -295,7 +295,7 @@ impl<ADC: Adc> PoweredAdc<ADC> {
         Ok(self.raw_to_voltage(measurement, atten)?)
     }
 
-    #[cfg(esp32)]
+    #[cfg(all(esp32, esp_idf_version_major = "4"))]
     fn read_hall(&mut self) -> nb::Result<u16, EspError> {
         let measurement = unsafe { hall_sensor_read() };
 


### PR DESCRIPTION
As per https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/peripherals.html#adc, the hall sensor is now unsupported