### PR TITLE
reset_reason: wrap `esp_reset_reason()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ pub mod mutex;
 pub mod peripherals;
 pub mod prelude;
 #[cfg(not(feature = "riscv-ulp-hal"))]
+pub mod reset_reason;
+#[cfg(not(feature = "riscv-ulp-hal"))]
 pub mod rmt;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub mod serial;

--- a/src/reset_reason.rs
+++ b/src/reset_reason.rs
@@ -1,0 +1,59 @@
+use core::{
+    convert::{TryFrom, TryInto},
+    fmt,
+};
+use esp_idf_sys::*;
+
+#[derive(Debug)]
+pub enum ResetReason {
+    Software,
+    ExternalPin,
+    Watchdog,
+    Sdio,
+    Panic,
+    InterruptWatchdog,
+    PowerOn,
+    Unknown,
+    Brownout,
+    TaskWatchdog,
+    DeepSleep,
+}
+
+#[derive(Debug)]
+pub struct InvalidResetReason(esp_reset_reason_t);
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidResetReason {}
+
+impl fmt::Display for InvalidResetReason {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "reset reason {} does not match a known value", self.0)
+    }
+}
+
+impl TryFrom<esp_reset_reason_t> for ResetReason {
+    type Error = InvalidResetReason;
+
+    #[allow(non_upper_case_globals)]
+    fn try_from(value: esp_reset_reason_t) -> Result<Self, Self::Error> {
+        Ok(match value {
+            esp_reset_reason_t_ESP_RST_SW => ResetReason::Software,
+            esp_reset_reason_t_ESP_RST_EXT => ResetReason::ExternalPin,
+            esp_reset_reason_t_ESP_RST_WDT => ResetReason::Watchdog,
+            esp_reset_reason_t_ESP_RST_SDIO => ResetReason::Sdio,
+            esp_reset_reason_t_ESP_RST_PANIC => ResetReason::Panic,
+            esp_reset_reason_t_ESP_RST_INT_WDT => ResetReason::InterruptWatchdog,
+            esp_reset_reason_t_ESP_RST_POWERON => ResetReason::PowerOn,
+            esp_reset_reason_t_ESP_RST_UNKNOWN => ResetReason::Unknown,
+            esp_reset_reason_t_ESP_RST_BROWNOUT => ResetReason::Brownout,
+            esp_reset_reason_t_ESP_RST_TASK_WDT => ResetReason::TaskWatchdog,
+            esp_reset_reason_t_ESP_RST_DEEPSLEEP => ResetReason::DeepSleep,
+            _ => return Err(InvalidResetReason(value)),
+        })
+    }
+}
+
+pub fn reset_reason() -> Result<ResetReason, InvalidResetReason> {
+    let rr = unsafe { esp_reset_reason() };
+    rr.try_into()
+}

--- a/src/reset_reason.rs
+++ b/src/reset_reason.rs
@@ -1,17 +1,31 @@
+//! Reset reasons
 use esp_idf_sys::*;
 
+/// Reset reasons
+#[doc(alias = "esp_reset_reason_t")]
 #[derive(Debug)]
 pub enum ResetReason {
+    /// Software restart via `esp_restart()`
     Software,
+    /// Reset by external pin
     ExternalPin,
+    /// Reset due to other watchdogs
     Watchdog,
+    /// Reset over SDIO
     Sdio,
+    /// Software reset due to exception/panic
     Panic,
+    /// Reset (software or hardware) due to interrupt watchdog
     InterruptWatchdog,
+    /// Reset due to power-on event
     PowerOn,
+    /// Reset reason can not be determined
     Unknown,
+    /// Brownout reset (software or hardware)
     Brownout,
+    /// Reset due to task watchdog
     TaskWatchdog,
+    /// Reset after exiting deep sleep mode
     DeepSleep,
 }
 
@@ -30,12 +44,20 @@ impl From<esp_reset_reason_t> for ResetReason {
             esp_reset_reason_t_ESP_RST_BROWNOUT => ResetReason::Brownout,
             esp_reset_reason_t_ESP_RST_TASK_WDT => ResetReason::TaskWatchdog,
             esp_reset_reason_t_ESP_RST_DEEPSLEEP => ResetReason::DeepSleep,
-            _ => panic!(),
+            _ => unreachable!(),
         }
     }
 }
 
-pub fn reset_reason() -> ResetReason {
-    let rr = unsafe { esp_reset_reason() };
-    rr.into()
+impl ResetReason {
+    /// Get the reason for the last reset
+    #[doc(alias = "esp_reset_reason")]
+    pub fn get() -> ResetReason {
+        // SAFETY: `esp_reset_reason()` reads from static memory that is initialized when
+        // constructors run and never modified after that point. We would only see
+        // uninitialized/partially initialized data if we run before main() (and before
+        // constructors running).
+        let rr = unsafe { esp_reset_reason() };
+        rr.into()
+    }
 }

--- a/src/reset_reason.rs
+++ b/src/reset_reason.rs
@@ -1,7 +1,3 @@
-use core::{
-    convert::{TryFrom, TryInto},
-    fmt,
-};
 use esp_idf_sys::*;
 
 #[derive(Debug)]
@@ -19,24 +15,10 @@ pub enum ResetReason {
     DeepSleep,
 }
 
-#[derive(Debug)]
-pub struct InvalidResetReason(esp_reset_reason_t);
-
-#[cfg(feature = "std")]
-impl std::error::Error for InvalidResetReason {}
-
-impl fmt::Display for InvalidResetReason {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "reset reason {} does not match a known value", self.0)
-    }
-}
-
-impl TryFrom<esp_reset_reason_t> for ResetReason {
-    type Error = InvalidResetReason;
-
+impl From<esp_reset_reason_t> for ResetReason {
     #[allow(non_upper_case_globals)]
-    fn try_from(value: esp_reset_reason_t) -> Result<Self, Self::Error> {
-        Ok(match value {
+    fn from(value: esp_reset_reason_t) -> Self {
+        match value {
             esp_reset_reason_t_ESP_RST_SW => ResetReason::Software,
             esp_reset_reason_t_ESP_RST_EXT => ResetReason::ExternalPin,
             esp_reset_reason_t_ESP_RST_WDT => ResetReason::Watchdog,
@@ -48,12 +30,12 @@ impl TryFrom<esp_reset_reason_t> for ResetReason {
             esp_reset_reason_t_ESP_RST_BROWNOUT => ResetReason::Brownout,
             esp_reset_reason_t_ESP_RST_TASK_WDT => ResetReason::TaskWatchdog,
             esp_reset_reason_t_ESP_RST_DEEPSLEEP => ResetReason::DeepSleep,
-            _ => return Err(InvalidResetReason(value)),
-        })
+            _ => panic!(),
+        }
     }
 }
 
-pub fn reset_reason() -> Result<ResetReason, InvalidResetReason> {
+pub fn reset_reason() -> ResetReason {
     let rr = unsafe { esp_reset_reason() };
-    rr.try_into()
+    rr.into()
 }


### PR DESCRIPTION
Primarily useful because this gives me a readable `Debug` impl for the reset reason. There may be a way to have `esp-idf-sys` generate some more reasonable code as an alternative.

Invoking this looks a bit funny because the module name and the type name are similar:

```
let rr = esp_idf_hal::reset_reason::ResetReason::get()
```

Open to changing it so it looks different, if others have ideas about how to better form this.