### PR TITLE
Implement uart2 for esp32-s3.

### DIFF
--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -34,7 +34,7 @@ pub struct Peripherals {
     pub uart0: uart::UART0,
     #[cfg(not(feature = "riscv-ulp-hal"))]
     pub uart1: uart::UART1,
-    #[cfg(all(esp32, not(feature = "riscv-ulp-hal")))]
+    #[cfg(all(any(esp32, esp32s3), not(feature = "riscv-ulp-hal")))]
     pub uart2: uart::UART2,
     #[cfg(not(feature = "riscv-ulp-hal"))]
     pub i2c0: i2c::I2C0,
@@ -136,7 +136,7 @@ impl Peripherals {
             uart0: uart::UART0::new(),
             #[cfg(not(feature = "riscv-ulp-hal"))]
             uart1: uart::UART1::new(),
-            #[cfg(all(esp32, not(feature = "riscv-ulp-hal")))]
+            #[cfg(all(any(esp32, esp32s3), not(feature = "riscv-ulp-hal")))]
             uart2: uart::UART2::new(),
             #[cfg(not(feature = "riscv-ulp-hal"))]
             i2c0: i2c::I2C0::new(),

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -664,5 +664,5 @@ fn check_nb<T>(result: Result<usize, EspError>, value: T) -> nb::Result<T, Seria
 
 impl_uart!(UART0: 0);
 impl_uart!(UART1: 1);
-#[cfg(esp32)]
+#[cfg(any(esp32, esp32s3))]
 impl_uart!(UART2: 2);


### PR DESCRIPTION
The esp32-s3 ([datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf)) has three UARTs, so `uart2` should be exposed in the HAL.

<img width="694" alt="Screen Shot 2022-09-25 at 9 13 56 PM" src="https://user-images.githubusercontent.com/147919/192163330-332ff188-eecd-4bef-9627-be08990b23ec.png">
