### PR TITLE
Fix issue #99: De-assert SPI CS on last transmit

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -466,7 +466,6 @@ impl<'d, SPI: Spi> SpiMasterDriver<'d, SPI> {
         core::mem::drop(lock);
 
         let result = trans_result?;
-        finish_result?;
         flush_result?;
 
         Ok(result)


### PR DESCRIPTION
The root cause of #99 seems to be that the behavior of `spi_device_polling_transmit` and `spi_device_transmit` for zero-byte transmissions differs between ESP32 hardware versions and appears to be undefined. This pull request removes the zero-byte call to `spi_device_polling_transmit` and instead assures the final call to `spi_device_polling_transmit` with non-zero rx/tx buffer do not contain the `SPI_TRANS_CS_KEEP_ACTIVE` flag.