### PR TITLE
Improvement: Infallible GPIO

### DIFF
--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -16,11 +16,11 @@ fn main() -> anyhow::Result<()> {
     let mut led = PinDriver::output(peripherals.pins.gpio4)?;
 
     loop {
-        led.set_high()?;
+        led.set_high();
         // we are sleeping here to make sure the watchdog isn't triggered
         FreeRtos::delay_ms(1000);
 
-        led.set_low()?;
+        led.set_low();
         FreeRtos::delay_ms(1000);
     }
 }

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -27,9 +27,9 @@ fn main() -> anyhow::Result<()> {
         thread::sleep(Duration::from_millis(10));
 
         if button.is_high() {
-            led.set_low()?;
+            led.set_low();
         } else {
-            led.set_high()?;
+            led.set_high();
         }
     }
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,5 +1,6 @@
 //! GPIO and pin configuration
 
+use core::convert::Infallible;
 use core::marker::PhantomData;
 
 #[cfg(feature = "alloc")]
@@ -1120,7 +1121,7 @@ impl<'d, T: Pin, MODE> embedded_hal_0_2::digital::v2::InputPin for PinDriver<'d,
 where
     MODE: InputMode,
 {
-    type Error = EspError;
+    type Error = Infallible;
 
     fn is_high(&self) -> Result<bool, Self::Error> {
         Ok(PinDriver::is_high(self))
@@ -1132,7 +1133,7 @@ where
 }
 
 impl<'d, T: Pin, MODE> embedded_hal::digital::ErrorType for PinDriver<'d, T, MODE> {
-    type Error = EspError;
+    type Error = Infallible;
 }
 
 impl<'d, T: Pin, MODE> embedded_hal::digital::blocking::InputPin for PinDriver<'d, T, MODE>
@@ -1152,7 +1153,7 @@ impl<'d, T: Pin, MODE> embedded_hal_0_2::digital::v2::OutputPin for PinDriver<'d
 where
     MODE: OutputMode,
 {
-    type Error = EspError;
+    type Error = Infallible;
 
     fn set_high(&mut self) -> Result<(), Self::Error> {
         self.set_level(Level::High);
@@ -1210,7 +1211,7 @@ impl<'d, T: Pin, MODE> embedded_hal_0_2::digital::v2::ToggleableOutputPin for Pi
 where
     MODE: OutputMode,
 {
-    type Error = EspError;
+    type Error = Infallible;
 
     fn toggle(&mut self) -> Result<(), Self::Error> {
         self.toggle();

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1225,7 +1225,6 @@ where
     MODE: OutputMode,
 {
     fn toggle(&mut self) -> Result<(), Self::Error> {
-        
         self.toggle();
         Ok(())
     }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -896,24 +896,24 @@ impl<'d, T: Pin, MODE> PinDriver<'d, T, MODE> {
     }
 
     #[inline]
-    pub fn set_high(&mut self) -> Result<(), EspError>
+    pub fn set_high(&mut self)
     where
         MODE: OutputMode,
     {
-        self.set_level(Level::High)
+        self.set_level(Level::High);
     }
 
     /// Set the output as low.
     #[inline]
-    pub fn set_low(&mut self) -> Result<(), EspError>
+    pub fn set_low(&mut self)
     where
         MODE: OutputMode,
     {
-        self.set_level(Level::Low)
+        self.set_level(Level::Low);
     }
 
     #[inline]
-    pub fn set_level(&mut self, level: Level) -> Result<(), EspError>
+    pub fn set_level(&mut self, level: Level)
     where
         MODE: OutputMode,
     {
@@ -924,27 +924,25 @@ impl<'d, T: Pin, MODE> PinDriver<'d, T, MODE> {
 
         if MODE::RTC {
             #[cfg(all(not(feature = "riscv-ulp-hal"), not(esp32c3)))]
-            esp!(unsafe { rtc_gpio_set_level(self.pin.pin(), on) })?;
+            esp!(unsafe { rtc_gpio_set_level(self.pin.pin(), on) }).unwrap();
 
             #[cfg(any(feature = "riscv-ulp-hal", esp32c3))]
             unreachable!();
         } else {
-            esp!(unsafe { gpio_set_level(self.pin.pin(), on) })?;
+            esp!(unsafe { gpio_set_level(self.pin.pin(), on) }).unwrap();
         }
-
-        Ok(())
     }
 
     /// Toggle pin output
     #[inline]
-    pub fn toggle(&mut self) -> Result<(), EspError>
+    pub fn toggle(&mut self)
     where
         MODE: OutputMode,
     {
         if self.is_set_low() {
-            self.set_high()
+            self.set_high();
         } else {
-            self.set_low()
+            self.set_low();
         }
     }
 
@@ -1157,11 +1155,13 @@ where
     type Error = EspError;
 
     fn set_high(&mut self) -> Result<(), Self::Error> {
-        self.set_level(Level::High)
+        self.set_level(Level::High);
+        Ok(())
     }
 
     fn set_low(&mut self) -> Result<(), Self::Error> {
-        self.set_level(Level::Low)
+        self.set_level(Level::Low);
+        Ok(())
     }
 }
 
@@ -1170,11 +1170,13 @@ where
     MODE: OutputMode,
 {
     fn set_high(&mut self) -> Result<(), Self::Error> {
-        self.set_level(Level::High)
+        self.set_level(Level::High);
+        Ok(())
     }
 
     fn set_low(&mut self) -> Result<(), Self::Error> {
-        self.set_level(Level::Low)
+        self.set_level(Level::Low);
+        Ok(())
     }
 }
 
@@ -1211,7 +1213,8 @@ where
     type Error = EspError;
 
     fn toggle(&mut self) -> Result<(), Self::Error> {
-        self.set_level(Level::from(!bool::from(self.get_output_level())))
+        self.toggle();
+        Ok(())
     }
 }
 
@@ -1221,7 +1224,9 @@ where
     MODE: OutputMode,
 {
     fn toggle(&mut self) -> Result<(), Self::Error> {
-        self.set_level(Level::from(!bool::from(self.get_output_level())))
+        
+        self.toggle();
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This is a first draft of an implementation for infallible GPIO (see issue #135) could look like.

For now it unwraps the `Result` of `gpio_set_level`. It probably would be better to use `expect` or use `assert` or even `debug_assert`. What is your opinion?

I also noticed that it should be possible to make `set_pull` infallible as well, but I have not done that change yet.