### PR TITLE
Migrate to `embedded-hal` 1.0.0-alpha.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,12 @@ embassy-time-isr-queue-timer10 = ["embassy-time", "embassy-sync"]
 embassy-time-isr-queue-timer11 = ["embassy-time", "embassy-sync"]
 
 [dependencies]
-nb = "0.1.2"
-embedded-hal = "=1.0.0-alpha.8"
+nb = "1.0.0"
+embedded-can = "0.4.1"
+embedded-hal = "=1.0.0-alpha.9"
 embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"] }
-esp-idf-sys = { version = "0.31.9", optional = true, default-features = false, features = ["native"] }
+embedded-hal-nb = "=1.0.0-alpha.1"
+esp-idf-sys = { version = "0.31.10", optional = true, default-features = false, features = ["native"] }
 critical-section = { version = "1.1", optional = true }
 heapless = "0.7"
 embassy-sync = { version = "0.1", optional = true, git = "https://github.com/ivmarkov/embassy" }
@@ -35,9 +37,9 @@ embassy-time = { version = "0.1", optional = true, features = ["tick-hz-1_000_00
 edge-executor = { version = "0.2", optional = true, default-features = false }
 
 [build-dependencies]
-embuild = "0.30.3"
+embuild = "0.30.4"
 anyhow = "1"
 
 [dev-dependencies]
 anyhow = "1"
-esp-idf-sys = { version = "0.31.9", features = ["native", "binstart"] }
+esp-idf-sys = { version = "0.31.10", features = ["native", "binstart"] }

--- a/examples/ledc-simple.rs
+++ b/examples/ledc-simple.rs
@@ -1,5 +1,3 @@
-use embedded_hal::delay::blocking::DelayUs;
-
 use esp_idf_hal::delay::FreeRtos;
 use esp_idf_hal::ledc::*;
 use esp_idf_hal::peripherals::Peripherals;

--- a/examples/rmt_morse_code.rs
+++ b/examples/rmt_morse_code.rs
@@ -14,8 +14,6 @@
 //! * Background sending.
 //! * Taking a [`Pin`] and [`Channel`] by ref mut, so that they can be used again later.
 //!
-use embedded_hal::delay::blocking::DelayUs;
-
 use esp_idf_hal::delay::Ets;
 use esp_idf_hal::gpio::*;
 use esp_idf_hal::peripheral::*;
@@ -80,7 +78,7 @@ fn send_morse_code<'d>(
     let pulses: Vec<&Pulse> = pulses.iter().collect();
     signal.push(pulses)?;
 
-    let mut tx = RmtDriver::new(channel, led, &config)?;
+    let mut tx = RmtDriver::new(channel, led, config)?;
     tx.start(signal)?;
 
     // Return `tx` so we can release the pin and channel later.

--- a/examples/rmt_musical_buzzer.rs
+++ b/examples/rmt_musical_buzzer.rs
@@ -6,8 +6,6 @@
 //! https://github.com/espressif/esp-idf/blob/b092fa073047c957545a0ae9504f04972a8c6d74/examples/peripherals/rmt/musical_buzzer/main/musical_buzzer_example_main.c
 use core::time::Duration;
 
-use embedded_hal::delay::blocking::DelayUs;
-
 use esp_idf_hal::delay::Ets;
 use esp_idf_hal::peripherals::Peripherals;
 use esp_idf_hal::rmt::config::{Loop, TransmitConfig};

--- a/examples/rmt_neopixel.rs
+++ b/examples/rmt_neopixel.rs
@@ -13,8 +13,6 @@
 
 use core::time::Duration;
 
-use embedded_hal::delay::blocking::DelayUs;
-
 use esp_idf_hal::delay::Ets;
 use esp_idf_hal::peripherals::Peripherals;
 use esp_idf_hal::rmt::config::TransmitConfig;

--- a/examples/spi_loopback.rs
+++ b/examples/spi_loopback.rs
@@ -14,7 +14,7 @@
 use std::thread;
 use std::time::Duration;
 
-use embedded_hal::spi::blocking::SpiDevice;
+use embedded_hal::spi::SpiDevice;
 
 use esp_idf_hal::peripherals::Peripherals;
 use esp_idf_hal::prelude::*;

--- a/src/can.rs
+++ b/src/can.rs
@@ -6,9 +6,9 @@
 //!
 //! Create a CAN peripheral and then transmit and receive a message.
 //! ```
-//! use embedded_hal::can::nb::Can;
-//! use embedded_hal::can::Frame;
-//! use embedded_hal::can::StandardId;
+//! use embedded_can::nb::Can;
+//! use embedded_can::Frame;
+//! use embedded_can::StandardId;
 //! use esp_idf_hal::prelude::*;
 //! use esp_idf_hal::can;
 //!
@@ -38,11 +38,7 @@ use crate::delay::{BLOCK, NON_BLOCK};
 use crate::gpio::*;
 use crate::peripheral::{Peripheral, PeripheralRef};
 
-crate::embedded_hal_error!(
-    CanError,
-    embedded_hal::can::Error,
-    embedded_hal::can::ErrorKind
-);
+crate::embedded_hal_error!(CanError, embedded_can::Error, embedded_can::ErrorKind);
 
 crate::embedded_hal_error!(
     Can02Error,
@@ -319,7 +315,7 @@ impl<'d> embedded_hal_0_2::blocking::can::Can for CanDriver<'d> {
     }
 }
 
-impl<'d> embedded_hal::can::blocking::Can for CanDriver<'d> {
+impl<'d> embedded_can::blocking::Can for CanDriver<'d> {
     type Frame = Frame;
     type Error = CanError;
 
@@ -354,7 +350,7 @@ impl<'d> embedded_hal_0_2::can::nb::Can for CanDriver<'d> {
     }
 }
 
-impl<'d> embedded_hal::can::nb::Can for CanDriver<'d> {
+impl<'d> embedded_can::nb::Can for CanDriver<'d> {
     type Frame = Frame;
     type Error = CanError;
 
@@ -524,20 +520,20 @@ impl embedded_hal_0_2::can::Frame for Frame {
     }
 }
 
-impl embedded_hal::can::Frame for Frame {
-    fn new(id: impl Into<embedded_hal::can::Id>, data: &[u8]) -> Option<Self> {
+impl embedded_can::Frame for Frame {
+    fn new(id: impl Into<embedded_can::Id>, data: &[u8]) -> Option<Self> {
         let (id, extended) = match id.into() {
-            embedded_hal::can::Id::Standard(id) => (id.as_raw() as u32, false),
-            embedded_hal::can::Id::Extended(id) => (id.as_raw(), true),
+            embedded_can::Id::Standard(id) => (id.as_raw() as u32, false),
+            embedded_can::Id::Extended(id) => (id.as_raw(), true),
         };
 
         Self::new(id, extended, data)
     }
 
-    fn new_remote(id: impl Into<embedded_hal::can::Id>, dlc: usize) -> Option<Self> {
+    fn new_remote(id: impl Into<embedded_can::Id>, dlc: usize) -> Option<Self> {
         let (id, extended) = match id.into() {
-            embedded_hal::can::Id::Standard(id) => (id.as_raw() as u32, false),
-            embedded_hal::can::Id::Extended(id) => (id.as_raw(), true),
+            embedded_can::Id::Standard(id) => (id.as_raw() as u32, false),
+            embedded_can::Id::Extended(id) => (id.as_raw(), true),
         };
 
         Self::new_remote(id, extended, dlc)
@@ -559,14 +555,13 @@ impl embedded_hal::can::Frame for Frame {
         !self.is_remote_frame()
     }
 
-    fn id(&self) -> embedded_hal::can::Id {
+    fn id(&self) -> embedded_can::Id {
         if self.is_standard() {
-            let id =
-                unsafe { embedded_hal::can::StandardId::new_unchecked(self.identifier() as u16) };
-            embedded_hal::can::Id::Standard(id)
+            let id = unsafe { embedded_can::StandardId::new_unchecked(self.identifier() as u16) };
+            embedded_can::Id::Standard(id)
         } else {
-            let id = unsafe { embedded_hal::can::ExtendedId::new_unchecked(self.identifier()) };
-            embedded_hal::can::Id::Extended(id)
+            let id = unsafe { embedded_can::ExtendedId::new_unchecked(self.identifier()) };
+            embedded_can::Id::Extended(id)
         }
     }
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -110,7 +110,7 @@ impl embedded_hal_0_2::blocking::delay::DelayMs<u8> for Ets {
     }
 }
 
-impl embedded_hal::delay::blocking::DelayUs for Ets {
+impl embedded_hal::delay::DelayUs for Ets {
     type Error = Infallible;
 
     fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
@@ -185,7 +185,7 @@ impl embedded_hal_0_2::blocking::delay::DelayMs<u8> for FreeRtos {
     }
 }
 
-impl embedded_hal::delay::blocking::DelayUs for FreeRtos {
+impl embedded_hal::delay::DelayUs for FreeRtos {
     type Error = Infallible;
 
     fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1137,7 +1137,7 @@ impl<'d, T: Pin, MODE> embedded_hal::digital::ErrorType for PinDriver<'d, T, MOD
     type Error = EspError;
 }
 
-impl<'d, T: Pin, MODE> embedded_hal::digital::blocking::InputPin for PinDriver<'d, T, MODE>
+impl<'d, T: Pin, MODE> embedded_hal::digital::InputPin for PinDriver<'d, T, MODE>
 where
     MODE: InputMode,
 {
@@ -1165,7 +1165,7 @@ where
     }
 }
 
-impl<'d, T: Pin, MODE> embedded_hal::digital::blocking::OutputPin for PinDriver<'d, T, MODE>
+impl<'d, T: Pin, MODE> embedded_hal::digital::OutputPin for PinDriver<'d, T, MODE>
 where
     MODE: OutputMode,
 {
@@ -1178,7 +1178,7 @@ where
     }
 }
 
-impl<'d, T: Pin, MODE> embedded_hal::digital::blocking::StatefulOutputPin for PinDriver<'d, T, MODE>
+impl<'d, T: Pin, MODE> embedded_hal::digital::StatefulOutputPin for PinDriver<'d, T, MODE>
 where
     MODE: OutputMode,
 {
@@ -1215,8 +1215,7 @@ where
     }
 }
 
-impl<'d, T: Pin, MODE> embedded_hal::digital::blocking::ToggleableOutputPin
-    for PinDriver<'d, T, MODE>
+impl<'d, T: Pin, MODE> embedded_hal::digital::ToggleableOutputPin for PinDriver<'d, T, MODE>
 where
     MODE: OutputMode,
 {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -9,7 +9,7 @@ use crate::gpio::*;
 use crate::peripheral::{Peripheral, PeripheralRef};
 use crate::units::*;
 
-pub use embedded_hal::i2c::blocking::Operation;
+pub use embedded_hal::i2c::Operation;
 
 crate::embedded_hal_error!(
     I2cError,
@@ -349,7 +349,7 @@ where
     type Error = I2cError;
 }
 
-impl<'d, I2C> embedded_hal::i2c::blocking::I2c<embedded_hal::i2c::SevenBitAddress>
+impl<'d, I2C> embedded_hal::i2c::I2c<embedded_hal::i2c::SevenBitAddress>
     for I2cMasterDriver<'d, I2C>
 where
     I2C: I2c,
@@ -388,14 +388,14 @@ where
     fn transaction<'a>(
         &mut self,
         address: u8,
-        operations: &mut [embedded_hal::i2c::blocking::Operation<'a>],
+        operations: &mut [embedded_hal::i2c::Operation<'a>],
     ) -> Result<(), Self::Error> {
         I2cMasterDriver::transaction(self, address, operations, BLOCK).map_err(to_i2c_err)
     }
 
     fn transaction_iter<'a, O>(&mut self, _address: u8, _operations: O) -> Result<(), Self::Error>
     where
-        O: IntoIterator<Item = embedded_hal::i2c::blocking::Operation<'a>>,
+        O: IntoIterator<Item = embedded_hal::i2c::Operation<'a>>,
     {
         todo!()
     }

--- a/src/ledc.rs
+++ b/src/ledc.rs
@@ -10,16 +10,15 @@
 //!
 //! Create a 25 kHz PWM signal with 75 % duty cycle on GPIO 1
 //! ```
-//! use embedded_hal::pwm::blocking::PwmPin;
-//! use esp_idf_hal::ledc::{config::TimerConfig, Channel, Timer};
+//! use esp_idf_hal::ledc::{config::TimerConfig, Channel, LedcDriver, Timer};
 //! use esp_idf_hal::peripherals::Peripherals;
 //! use esp_idf_hal::prelude::*;
 //!
 //! let peripherals = Peripherals::take().unwrap();
-//! let driver = LedcDriver::new(peripherals.ledc.channel0, peripherals.ledc.timer0, peripherals.pins.gpio1, &TimerConfig::default().frequency(25.kHz().into()))?;
+//! let mut driver = LedcDriver::new(peripherals.ledc.channel0, peripherals.ledc.timer0, peripherals.pins.gpio1, &TimerConfig::default().frequency(25.kHz().into()))?;
 //!
 //! let max_duty = driver.get_max_duty()?;
-//! driver.set_duty(max_duty * 3 / 4);
+//! driver.set_duty(max_duty * 3 / 4)?;
 //! ```
 //!
 //! See the `examples/` folder of this repository for more.

--- a/src/riscv_ulp_hal/delay.rs
+++ b/src/riscv_ulp_hal/delay.rs
@@ -39,7 +39,7 @@ impl embedded_hal_0_2::blocking::delay::DelayMs<u8> for Ulp {
     }
 }
 
-impl embedded_hal::delay::blocking::DelayUs for Ulp {
+impl embedded_hal::delay::DelayUs for Ulp {
     type Error = core::convert::Infallible;
 
     fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -24,7 +24,7 @@ use core::cmp::{max, min, Ordering};
 use core::marker::PhantomData;
 use core::ptr;
 
-use embedded_hal::spi::blocking::{SpiBus, SpiBusFlush, SpiBusRead, SpiBusWrite, SpiDevice};
+use embedded_hal::spi::{SpiBus, SpiBusFlush, SpiBusRead, SpiBusWrite, SpiDevice};
 
 use esp_idf_sys::*;
 

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -475,9 +475,9 @@ impl<'d, UART: Uart> embedded_hal_0_2::serial::Read<u8> for UartDriver<'d, UART>
     }
 }
 
-impl<'d, UART: Uart> embedded_hal::serial::nb::Read<u8> for UartDriver<'d, UART> {
+impl<'d, UART: Uart> embedded_hal_nb::serial::Read<u8> for UartDriver<'d, UART> {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
-        embedded_hal::serial::nb::Read::read(&mut self.rx)
+        embedded_hal_nb::serial::Read::read(&mut self.rx)
     }
 }
 
@@ -493,13 +493,13 @@ impl<'d, UART: Uart> embedded_hal_0_2::serial::Write<u8> for UartDriver<'d, UART
     }
 }
 
-impl<'d, UART: Uart> embedded_hal::serial::nb::Write<u8> for UartDriver<'d, UART> {
+impl<'d, UART: Uart> embedded_hal_nb::serial::Write<u8> for UartDriver<'d, UART> {
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
-        embedded_hal::serial::nb::Write::flush(&mut self.tx)
+        embedded_hal_nb::serial::Write::flush(&mut self.tx)
     }
 
     fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
-        embedded_hal::serial::nb::Write::write(&mut self.tx, byte)
+        embedded_hal_nb::serial::Write::write(&mut self.tx, byte)
     }
 }
 
@@ -562,7 +562,7 @@ impl<'d, UART: Uart> embedded_hal_0_2::serial::Read<u8> for UartRxDriver<'d, UAR
     }
 }
 
-impl<'d, UART: Uart> embedded_hal::serial::nb::Read<u8> for UartRxDriver<'d, UART> {
+impl<'d, UART: Uart> embedded_hal_nb::serial::Read<u8> for UartRxDriver<'d, UART> {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         let mut buf = [0_u8];
 
@@ -610,7 +610,7 @@ impl<'d, UART: Uart> embedded_hal_0_2::serial::Write<u8> for UartTxDriver<'d, UA
     }
 }
 
-impl<'d, UART: Uart> embedded_hal::serial::nb::Write<u8> for UartTxDriver<'d, UART> {
+impl<'d, UART: Uart> embedded_hal_nb::serial::Write<u8> for UartTxDriver<'d, UART> {
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
         UartTxDriver::flush(self).map_err(to_nb_err)
     }


### PR DESCRIPTION
See https://github.com/rust-embedded/embedded-hal/releases/tag/v1.0.0-alpha.9

`embedded-can` and `embedded-hal-nb` were split out of the main crate