### PR TITLE
allows to specify spi transfer_size chunk length

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -362,7 +362,6 @@ impl<'d> SpiBus for SpiBusDriver<'d> {
 
 pub struct SpiDriver<'d> {
     host: u8,
-    //    max_transfer_size: usize,
     dma: Dma,
     _p: PhantomData<&'d mut ()>,
 }
@@ -383,7 +382,7 @@ impl<'d> SpiDriver<'d> {
 
         Ok(Self {
             host: SPI1::device() as _,
-            max_transfer_size,
+            dma,
             _p: PhantomData,
         })
     }
@@ -460,7 +459,7 @@ impl<'d> SpiDriver<'d> {
             quadwp_io_num: -1,
             quadhd_io_num: -1,
 
-            max_transfer_sz: max_transfer_sz as i32,
+            max_transfer_sz: dma.max_transfer_size() as i32,
             ..Default::default()
         };
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -163,6 +163,7 @@ pub mod config {
         ThirtyTwoBits = 4,
         FourtyEightBits = 6,
         SixtyFourBits = 8,
+        None = 64,
     }
 
     /// SPI Device configuration
@@ -229,7 +230,7 @@ pub mod config {
                 write_only: false,
                 cs_active_high: false,
                 duplex: Duplex::Full,
-                chunk_size: Chunk::SixtyFourBits,
+                chunk_size: Chunk::None,
             }
         }
     }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -975,7 +975,7 @@ fn polling_transmit(
     // This unfortunately means that this implementation is incorrect for esp-idf < 4.4.
     // The CS pin should be kept active through transactions.
     #[cfg(not(esp_idf_version = "4.3"))]
-    let mut flags = if _keep_cs_active {
+    let flags = if _keep_cs_active {
         SPI_TRANS_CS_KEEP_ACTIVE
     } else {
         0

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -378,7 +378,7 @@ impl<'d> SpiDriver<'d> {
         sdi: Option<impl Peripheral<P = crate::gpio::Gpio8> + 'd>,
         dma: Dma,
     ) -> Result<Self, EspError> {
-        let max_transfer_size = Self::new_internal(SPI1::device(), sclk, sdo, sdi, dma)?;
+        Self::new_internal(SPI1::device(), sclk, sdo, sdi, dma)?;
 
         Ok(Self {
             host: SPI1::device() as _,


### PR DESCRIPTION
if dma is not enabled the max_transfer size is used to determine the transfer chunk size. this is 64 bits. ->  every transaction shorter than 64 bits will be clocked out with continuous 64 clk cycle. often devices on spi wants an 8bit chunked version. 

Before Patch: 
![IMG_20221118_200405](https://user-images.githubusercontent.com/12041081/202783139-f153a5a9-1f26-4087-9a3b-5a954ed9e0d7.jpg)

With Patch:
![IMG_20221118_191511](https://user-images.githubusercontent.com/12041081/202783154-b686a1b9-4d91-47dc-9f52-704587a806fc.jpg)
![IMG_20221118_191914](https://user-images.githubusercontent.com/12041081/202783164-aad4f838-0581-4917-8872-6a1908296158.jpg)
![IMG_20221118_191821](https://user-images.githubusercontent.com/12041081/202783170-0e037963-f562-483a-92df-a6bedbf482d1.jpg)
