### PR TITLE
Implement exclusive SPI Bus

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -776,12 +776,6 @@ where
     }
 }
 
-impl<'d, T> Drop for SpiDeviceDriver<'d, T> {
-    fn drop(&mut self) {
-        esp!(unsafe { spi_bus_remove_device(self.handle) }).unwrap();
-    }
-}
-
 pub struct SpiSharedDeviceDriver<'d, T> {
     driver: UnsafeCell<SpiDeviceDriver<'d, T>>,
     cs: CriticalSection,


### PR DESCRIPTION
Fixes #163

`SpiBusDriver` is a struct to be used when one needs exclusive access to the SPI bus without interference from other devices.

I renamed the existing `SpiBusDriver` to `SpiSharedBusDriver` since it's a better fitting name IMO. It's not really a public type since users should be going through the e-hal trait or using type inference.

The `Device` struct was introduced to make Rust drop the `Lock` before calling `spi_bus_remove_device()`. Another way to achieve this is with `ManuallyDrop` but that requires `unsafe`.