### PR TITLE
Fix for issue 193 Failed to compile for IDF 5.0 (stable) due to missing esp_task_wdt_reconfigure() in IDF 5.0 (stable)

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -463,7 +463,7 @@ pub mod watchdog {
             TWDT_DRIVER_REF_COUNT.fetch_add(1, Ordering::SeqCst);
             let init_by_idf = Self::watchdog_is_init_by_idf();
 
-            #[cfg(not(esp_idf_version_major = "4"))]
+            #[cfg(all(not(esp_idf_version_major = "4"), not(esp_idf_version = "5.0")))]
             if !init_by_idf {
                 esp!(unsafe { esp_task_wdt_init(&config.into() as *const esp_task_wdt_config_t) })?;
             } else {
@@ -471,6 +471,9 @@ pub mod watchdog {
                     esp_task_wdt_reconfigure(&config.into() as *const esp_task_wdt_config_t)
                 })?;
             }
+
+            #[cfg(esp_idf_version = "5.0")]
+            esp!(unsafe { esp_task_wdt_init(&config.into() as *const esp_task_wdt_config_t) })?;
 
             #[cfg(esp_idf_version_major = "4")]
             esp!(unsafe {


### PR DESCRIPTION
This fixing issue https://github.com/esp-rs/esp-idf-hal/issues/193

Compiling esp-idf-master master against IDF stable 5.0 fails as the function esp_task_wdt_reconfigure has only been introduced on the master(latest) unstable branch of IDF.