### PR TITLE
Correct endianness of RMT signal in neopixel example

### DIFF
--- a/examples/rmt_neopixel.rs
+++ b/examples/rmt_neopixel.rs
@@ -1,7 +1,5 @@
 //! A simple example to change colours of a WS2812/NeoPixel compatible LED.
 //!
-//! It is set to pin 18 which some dev boards have connected to a compatible LED.
-//!
 //! This example demonstrates the use of [`FixedLengthSignal`][crate::rmt::FixedLengthSignal] which
 //! lives on the stack and requires a known length before creating it.
 //!
@@ -11,43 +9,120 @@
 //! Datasheet (PDF) for a WS2812, which explains how the pulses are to be sent:
 //! https://cdn-shop.adafruit.com/datasheets/WS2812.pdf
 
+use anyhow::{bail, Result};
 use core::time::Duration;
-
-use esp_idf_hal::delay::Ets;
+use embedded_hal::delay::DelayUs;
+use esp_idf_hal::delay::FreeRtos;
 use esp_idf_hal::peripherals::Peripherals;
 use esp_idf_hal::rmt::config::TransmitConfig;
 use esp_idf_hal::rmt::*;
 
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<()> {
     esp_idf_sys::link_patches();
+    esp_idf_svc::log::EspLogger::initialize_default();
 
     let peripherals = Peripherals::take().unwrap();
-    let led = peripherals.pins.gpio18;
+    // Onboard RGB LED pin
+    // ESP32-C3-DevKitC-02 gpio8, esp-rs gpio2
+    let led = peripherals.pins.gpio2;
     let channel = peripherals.rmt.channel0;
     let config = TransmitConfig::new().clock_divider(1);
     let mut tx = TxRmtDriver::new(channel, led, &config)?;
 
-    let rgbs = [0xff0000, 0xffff00, 0x00ffff, 0x00ff00, 0xa000ff];
-    loop {
-        for rgb in rgbs {
-            let ticks_hz = tx.counter_clock()?;
-            let t0h = Pulse::new_with_duration(ticks_hz, PinState::High, &ns(350))?;
-            let t0l = Pulse::new_with_duration(ticks_hz, PinState::Low, &ns(800))?;
-            let t1h = Pulse::new_with_duration(ticks_hz, PinState::High, &ns(700))?;
-            let t1l = Pulse::new_with_duration(ticks_hz, PinState::Low, &ns(600))?;
+    // 3 seconds white at 10% brightness  
+    neopixel(RGB { r: 25, g: 25, b: 25 }, &mut tx)?;
+    FreeRtos.delay_ms(3000)?;
 
-            let mut signal = FixedLengthSignal::<24>::new();
-            for i in 0..24 {
-                let bit = 2_u32.pow(i) & rgb != 0;
-                let (high_pulse, low_pulse) = if bit { (t1h, t1l) } else { (t0h, t0l) };
-                signal.set(i as usize, &(high_pulse, low_pulse))?;
-            }
-            tx.start_blocking(&signal)?;
-            Ets::delay_ms(1000);
+    // rainbow loop at 20% brightness
+    let mut i: u32 = 0;
+    loop {
+        let rgb = hsv2rgb(i, 100, 20)?;
+        neopixel(rgb, &mut tx)?;
+        if i == 360 {
+            i = 0;
         }
+        i += 1;
+        FreeRtos.delay_ms(10)?;
     }
+}
+
+struct RGB {
+    r: u8,
+    g: u8,
+    b: u8,
 }
 
 fn ns(nanos: u64) -> Duration {
     Duration::from_nanos(nanos)
+}
+
+fn neopixel(rgb: RGB, tx: &mut TxRmtDriver) -> Result<()> {
+    // e.g. rgb: (1,2,4)
+    // G        R        B
+    // 7      0 7      0 7      0
+    // 00000010 00000001 00000100
+    let color: u32 = ((rgb.g as u32) << 16) | ((rgb.r as u32) << 8) | rgb.b as u32;
+    let ticks_hz = tx.counter_clock()?;
+    let t0h = Pulse::new_with_duration(ticks_hz, PinState::High, &ns(350))?;
+    let t0l = Pulse::new_with_duration(ticks_hz, PinState::Low, &ns(800))?;
+    let t1h = Pulse::new_with_duration(ticks_hz, PinState::High, &ns(700))?;
+    let t1l = Pulse::new_with_duration(ticks_hz, PinState::Low, &ns(600))?;
+    let mut signal = FixedLengthSignal::<24>::new();
+    for i in (0..24).rev() {
+        let p = 2_u32.pow(i);
+        let bit = p & color != 0;
+        let (high_pulse, low_pulse) = if bit {
+            (t1h, t1l)
+        } else {
+            (t0h, t0l)
+        };
+        signal.set(23 - i as usize, &(high_pulse, low_pulse))?;
+    }
+    tx.start_blocking(&signal)?;
+
+    Ok(())
+}
+
+/// Converts hue, saturation, value to RGB
+fn hsv2rgb(h: u32, s: u32, v: u32) -> Result<RGB> {
+    if h > 360 || s > 100 || v > 100 {
+        bail!("The given HSV values are not in valid range");
+    }
+    let s = s as f64 / 100.0;
+    let v = v as f64 / 100.0;
+    let c = s * v;
+    let x = c * (1.0 - (((h as f64 / 60.0) % 2.0) - 1.0).abs());
+    let m = v - c;
+    let (r, g, b);
+    if h < 60 {
+        r = c;
+        g = x;
+        b = 0.0;
+    } else if h >= 60 && h < 120 {
+        r = x;
+        g = c;
+        b = 0.0;
+    } else if h >= 120 && h < 180 {
+        r = 0.0;
+        g = c;
+        b = x;
+    } else if h >= 180 && h < 240 {
+        r = 0.0;
+        g = x;
+        b = c;
+    } else if h >= 240 && h < 300 {
+        r = x;
+        g = 0.0;
+        b = c;
+    } else {
+        r = c;
+        g = 0.0;
+        b = x;
+    }
+
+    Ok(RGB {
+        r: ((r + m) * 255.0) as u8,
+        g: ((g + m) * 255.0) as u8,
+        b: ((b + m) * 255.0) as u8,
+    })
 }

--- a/examples/rmt_neopixel.rs
+++ b/examples/rmt_neopixel.rs
@@ -29,8 +29,15 @@ fn main() -> Result<()> {
     let config = TransmitConfig::new().clock_divider(1);
     let mut tx = TxRmtDriver::new(channel, led, &config)?;
 
-    // 3 seconds white at 10% brightness  
-    neopixel(RGB { r: 25, g: 25, b: 25 }, &mut tx)?;
+    // 3 seconds white at 10% brightness
+    neopixel(
+        RGB {
+            r: 25,
+            g: 25,
+            b: 25,
+        },
+        &mut tx,
+    )?;
     FreeRtos.delay_ms(3000)?;
 
     // rainbow loop at 20% brightness
@@ -71,11 +78,7 @@ fn neopixel(rgb: RGB, tx: &mut TxRmtDriver) -> Result<()> {
     for i in (0..24).rev() {
         let p = 2_u32.pow(i);
         let bit = p & color != 0;
-        let (high_pulse, low_pulse) = if bit {
-            (t1h, t1l)
-        } else {
-            (t0h, t0l)
-        };
+        let (high_pulse, low_pulse) = if bit { (t1h, t1l) } else { (t0h, t0l) };
         signal.set(23 - i as usize, &(high_pulse, low_pulse))?;
     }
     tx.start_blocking(&signal)?;

--- a/examples/rmt_neopixel.rs
+++ b/examples/rmt_neopixel.rs
@@ -11,7 +11,6 @@
 
 use anyhow::{bail, Result};
 use core::time::Duration;
-use embedded_hal::delay::DelayUs;
 use esp_idf_hal::delay::FreeRtos;
 use esp_idf_hal::peripherals::Peripherals;
 use esp_idf_hal::rmt::config::TransmitConfig;
@@ -19,7 +18,6 @@ use esp_idf_hal::rmt::*;
 
 fn main() -> Result<()> {
     esp_idf_sys::link_patches();
-    esp_idf_svc::log::EspLogger::initialize_default();
 
     let peripherals = Peripherals::take().unwrap();
     // Onboard RGB LED pin
@@ -38,7 +36,7 @@ fn main() -> Result<()> {
         },
         &mut tx,
     )?;
-    FreeRtos.delay_ms(3000)?;
+    FreeRtos::delay_ms(3000);
 
     // rainbow loop at 20% brightness
     let mut i: u32 = 0;
@@ -49,7 +47,7 @@ fn main() -> Result<()> {
             i = 0;
         }
         i += 1;
-        FreeRtos.delay_ms(10)?;
+        FreeRtos::delay_ms(10);
     }
 }
 


### PR DESCRIPTION
Bits were sent reversed, which worked for 0xff but not at smaller values to dim the LED. Also added rainbow example using a hsv function.