### PR TITLE
Update `xtensa-toolchain` action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   rust_toolchain: nightly
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   compile:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     name: Compile
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         target:
           - riscv32imc-esp-espidf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron: '50 4 * * *'
+    - cron: "50 4 * * *"
 
 env:
   rust_toolchain: nightly
@@ -45,13 +45,10 @@ jobs:
         if: matrix.target == 'riscv32imc-esp-espidf'
 
       - name: Install Rust for Xtensa
-        uses: esp-rs/xtensa-toolchain@v1.4.0
+        uses: esp-rs/xtensa-toolchain@v1.5
         with:
           default: true
         if: matrix.target != 'riscv32imc-esp-espidf'
-      
-      - name: Temp fix for clang error
-        run: sudo apt-get install libncurses5
 
       - name: Build | Fmt Check
         run: cargo fmt -- --check


### PR DESCRIPTION
- Avoid failing fast in the matrix
- Define `GITHUB_TOKEN`, see https://github.com/esp-rs/xtensa-toolchain#environment
- Remove `libncurses5` dependency
- Upgrade `xtensa-toolchain` version