### PR TITLE
i2c: allow setting a timeout to accommodate devices with longer clock stretching

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+use core::time::Duration;
 
 use embedded_hal::i2c::{ErrorKind, NoAcknowledgeSource};
 
@@ -17,12 +18,23 @@ crate::embedded_hal_error!(
     embedded_hal::i2c::ErrorKind
 );
 
+const APB_TICK_PERIOD_NS: u32 = 1_000_000_000 / 80_000_000;
+#[derive(Copy, Clone, Debug)]
+pub struct APBTickType(::core::ffi::c_int);
+impl From<Duration> for APBTickType {
+    fn from(duration: Duration) -> Self {
+        APBTickType(((duration.as_nanos() + APB_TICK_PERIOD_NS as u128 - 1) / APB_TICK_PERIOD_NS as u128)
+                as ::core::ffi::c_int)
+    }
+}
+
 pub type I2cConfig = config::Config;
 pub type I2cSlaveConfig = config::SlaveConfig;
 
 /// I2C configuration
 pub mod config {
     use crate::units::*;
+    use super::APBTickType;
 
     /// I2C Master configuration
     #[derive(Copy, Clone)]
@@ -30,6 +42,7 @@ pub mod config {
         pub baudrate: Hertz,
         pub sda_pullup_enabled: bool,
         pub scl_pullup_enabled: bool,
+        pub timeout: Option<APBTickType>,
     }
 
     impl Config {
@@ -54,6 +67,12 @@ pub mod config {
             self.scl_pullup_enabled = enable;
             self
         }
+
+        #[must_use]
+        pub fn timeout(mut self, timeout: APBTickType) -> Self {
+            self.timeout = Some(timeout);
+            self
+        }
     }
 
     impl Default for Config {
@@ -62,6 +81,7 @@ pub mod config {
                 baudrate: Hertz(1_000_000),
                 sda_pullup_enabled: true,
                 scl_pullup_enabled: true,
+                timeout: None,
             }
         }
     }
@@ -165,6 +185,10 @@ impl<'d> I2cDriver<'d> {
                 0,
             ) // TODO: set flags
         })?;
+
+        if let Some(timeout) = config.timeout {
+            esp!(unsafe{i2c_set_timeout(I2C::port(), timeout.0)})?;
+        }
 
         Ok(I2cDriver {
             i2c: I2C::port() as _,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -23,8 +23,10 @@ const APB_TICK_PERIOD_NS: u32 = 1_000_000_000 / 80_000_000;
 pub struct APBTickType(::core::ffi::c_int);
 impl From<Duration> for APBTickType {
     fn from(duration: Duration) -> Self {
-        APBTickType(((duration.as_nanos() + APB_TICK_PERIOD_NS as u128 - 1) / APB_TICK_PERIOD_NS as u128)
-                as ::core::ffi::c_int)
+        APBTickType(
+            ((duration.as_nanos() + APB_TICK_PERIOD_NS as u128 - 1) / APB_TICK_PERIOD_NS as u128)
+                as ::core::ffi::c_int,
+        )
     }
 }
 
@@ -33,8 +35,8 @@ pub type I2cSlaveConfig = config::SlaveConfig;
 
 /// I2C configuration
 pub mod config {
-    use crate::units::*;
     use super::APBTickType;
+    use crate::units::*;
 
     /// I2C Master configuration
     #[derive(Copy, Clone)]
@@ -187,7 +189,7 @@ impl<'d> I2cDriver<'d> {
         })?;
 
         if let Some(timeout) = config.timeout {
-            esp!(unsafe{i2c_set_timeout(I2C::port(), timeout.0)})?;
+            esp!(unsafe { i2c_set_timeout(I2C::port(), timeout.0) })?;
         }
 
         Ok(I2cDriver {


### PR DESCRIPTION
Some i2c devices require a longer timeout to allow clock stretching.  This PR adds an optional `timeout` to the i2c master config.