### PR TITLE
Alerts and modes support for TWAI

### DIFF
--- a/src/can.rs
+++ b/src/can.rs
@@ -253,6 +253,186 @@ pub mod config {
         }
     }
 
+    #[derive(Debug, Copy, Clone)]
+    pub struct Alerts {
+        value: u32,
+    }
+
+    impl Alerts {
+        const TWAI_ALERT_TX_SUCCESS: u32 = 0x00000002;
+        const TWAI_ALERT_TX_IDLE: u32 = 0x00000001;
+        const TWAI_ALERT_RX_DATA: u32 = 0x00000004;
+        const TWAI_ALERT_BELOW_ERR_WARN: u32 = 0x00000008;
+        const TWAI_ALERT_ERR_ACTIVE: u32 = 0x00000010;
+        const TWAI_ALERT_RECOVERY_IN_PROGRESS: u32 = 0x00000020;
+        const TWAI_ALERT_BUS_RECOVERED: u32 = 0x00000040;
+        const TWAI_ALERT_ARB_LOST: u32 = 0x00000080;
+        const TWAI_ALERT_ABOVE_ERR_WARN: u32 = 0x00000100;
+        const TWAI_ALERT_BUS_ERROR: u32 = 0x00000200;
+        const TWAI_ALERT_TX_FAILED: u32 = 0x00000400;
+        const TWAI_ALERT_RX_QUEUE_FULL: u32 = 0x00000800;
+        const TWAI_ALERT_ERR_PASS: u32 = 0x00001000;
+        const TWAI_ALERT_BUS_OFF: u32 = 0x00002000;
+        const TWAI_ALERT_RX_FIFO_OVERRUN: u32 = 0x00004000;
+        const TWAI_ALERT_TX_RETRIED: u32 = 0x00008000;
+        const TWAI_ALERT_PERIPH_RESET: u32 = 0x00010000;
+        const TWAI_ALERT_ALL: u32 = 0x0001FFFF;
+        const TWAI_ALERT_NONE: u32 = 0x00000000;
+        const TWAI_ALERT_AND_LOG: u32 = 0x00020000;
+
+        /// Create new `Alerts` with no alerts set.
+        pub const fn new() -> Self {
+            Self {
+                value: Self::TWAI_ALERT_NONE,
+            }
+        }
+
+        /// Enable the `TX_SUCCESS` alert: The previous transmission was successful.
+        pub fn tx_success(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_TX_SUCCESS,
+            }
+        }
+
+        /// Enable the `TX_IDLE` alert: No more messages to transmit.
+        pub fn tx_idle(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_TX_IDLE,
+            }
+        }
+
+        /// Enable the `RX_DATA` alert: A frame has been received and added to the RX queue.
+        pub fn rx_data(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_RX_DATA,
+            }
+        }
+
+        // Enable the `BELOW_ERR_WARN` alert: Both error counters have dropped below error warning limit. 
+        pub fn below_err_warn(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_BELOW_ERR_WARN,
+            }
+        }
+
+        // Enable the `ERR_ACTIVE` alert: TWAI controller has become error active.
+        pub fn err_active(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_ERR_ACTIVE,
+            }
+        }
+
+        // Enable the `RECOVERY_IN_PROGRESS` alert: TWAI controller is undergoing bus recovery.
+        pub fn recovery_in_progress(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_RECOVERY_IN_PROGRESS,
+            }
+        }
+
+        // Enable the `BUS_RECOVERED` alert: TWAI controller has successfully completed bus recovery.
+        pub fn bus_recovered(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_BUS_RECOVERED,
+            }
+        }
+
+        // Enable the `ARB_LOST` alert: The previous transmission lost arbitration.
+        pub fn arb_lost(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_ARB_LOST,
+            }
+        }
+
+        // Enable the `ABOVE_ERR_WARN` alert: One of the error counters have exceeded the error warning limit.
+        pub fn above_err_warn(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_ABOVE_ERR_WARN,
+            }
+        }
+
+        // Enable the `BUS_ERROR` alert: A (Bit, Stuff, CRC, Form, ACK) error has occurred on the bus.
+        pub fn bus_error(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_BUS_ERROR,
+            }
+        }
+
+        // Enable the `TX_FAILED` alert: The previous transmission has failed (for single shot transmission).
+        pub fn tx_failed(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_TX_FAILED,
+            }
+        }
+
+        // Enable the `RX_QUEUE_FULL` alert: The RX queue is full causing a frame to be lost.
+        pub fn rx_queue_full(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_RX_QUEUE_FULL,
+            }
+        }
+
+        // Enable the `ERR_PASS` alert: TWAI controller has become error passive.
+        pub fn err_pass(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_ERR_PASS,
+            }
+        }
+
+        // Enable the `BUS_OFF` alert: Bus-off condition occurred. TWAI controller can no longer influence bus.
+        pub fn bus_off(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_BUS_OFF,
+            }
+        }
+
+        // Enable the `RX_FIFO_OVERRUN` alert: An RX FIFO overrun has occurred.
+        pub fn rx_fifo_overrun(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_RX_FIFO_OVERRUN,
+            }
+        }
+
+        // Enable the `TX_RETRIED` alert: An message transmission was cancelled and retried due to an errata workaround.
+        pub fn tx_retried(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_TX_RETRIED,
+            }
+        }
+
+        // Enable the `PERIPH_RESET` alert: The TWAI controller was reset.
+        pub fn periph_reset(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_PERIPH_RESET,
+            }
+        }
+
+        // Enable all alerts.
+        pub fn all(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_ALL,
+            }
+        }
+
+        // Enable alert logging when they occur. Note that logging from the ISR is disabled if CONFIG_TWAI_ISR_IN_IRAM is enabled.
+        pub fn and_log(self) -> Self {
+            Self {
+                value: self.value | Self::TWAI_ALERT_AND_LOG,
+            }
+        }
+    }
+
+    impl From<Alerts> for u32 {
+        fn from(val: Alerts) -> Self {
+            val.value
+        }
+    }
+
+    impl Default for Alerts {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     #[derive(Debug, Copy, Clone, Default)]
     pub struct Config {
         pub timing: Timing,
@@ -260,6 +440,7 @@ pub mod config {
         pub tx_queue_len: u32,
         pub rx_queue_len: u32,
         pub mode: Mode,
+        pub alerts: Alerts,
     }
 
     impl Config {
@@ -297,6 +478,11 @@ pub mod config {
             self.mode = mode;
             self
         }
+
+        pub fn alerts(mut self, alerts: Alerts) -> Self {
+            self.alerts = alerts;
+            self
+        }
     }
 }
 
@@ -322,7 +508,7 @@ impl<'d> CanDriver<'d> {
             bus_off_io: -1,
             tx_queue_len: config.tx_queue_len,
             rx_queue_len: config.rx_queue_len,
-            alerts_enabled: TWAI_ALERT_NONE,
+            alerts_enabled: config.alerts.into(),
             clkout_divider: 0,
             intr_flags: ESP_INTR_FLAG_LEVEL1 as i32,
         };

--- a/src/can.rs
+++ b/src/can.rs
@@ -236,11 +236,30 @@ pub mod config {
     }
 
     #[derive(Debug, Copy, Clone, Default)]
+    pub enum Mode {
+        #[default]
+        Normal,
+        NoAck,
+        ListenOnly,
+    }
+
+    impl From<Mode> for twai_mode_t {
+        fn from(val: Mode) -> Self {
+            match val {
+                Mode::Normal => twai_mode_t_TWAI_MODE_NORMAL,
+                Mode::NoAck => twai_mode_t_TWAI_MODE_NO_ACK,
+                Mode::ListenOnly => twai_mode_t_TWAI_MODE_LISTEN_ONLY,
+            }
+        }
+    }
+
+    #[derive(Debug, Copy, Clone, Default)]
     pub struct Config {
         pub timing: Timing,
         pub filter: Filter,
         pub tx_queue_len: u32,
         pub rx_queue_len: u32,
+        pub mode: Mode,
     }
 
     impl Config {
@@ -273,6 +292,11 @@ pub mod config {
             self.rx_queue_len = rx_queue_len;
             self
         }
+
+        pub fn mode(mut self, mode: Mode) -> Self {
+            self.mode = mode;
+            self
+        }
     }
 }
 
@@ -291,7 +315,7 @@ impl<'d> CanDriver<'d> {
         crate::into_ref!(can, tx, rx);
 
         let general_config = twai_general_config_t {
-            mode: twai_mode_t_TWAI_MODE_NORMAL,
+            mode: config.mode.into(),
             tx_io: tx.pin(),
             rx_io: rx.pin(),
             clkout_io: -1,

--- a/src/can.rs
+++ b/src/can.rs
@@ -308,112 +308,112 @@ pub mod config {
             }
         }
 
-        // Enable the `BELOW_ERR_WARN` alert: Both error counters have dropped below error warning limit. 
+        /// Enable the `BELOW_ERR_WARN` alert: Both error counters have dropped below error warning limit.
         pub fn below_err_warn(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_BELOW_ERR_WARN,
             }
         }
 
-        // Enable the `ERR_ACTIVE` alert: TWAI controller has become error active.
+        /// Enable the `ERR_ACTIVE` alert: TWAI controller has become error active.
         pub fn err_active(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_ERR_ACTIVE,
             }
         }
 
-        // Enable the `RECOVERY_IN_PROGRESS` alert: TWAI controller is undergoing bus recovery.
+        /// Enable the `RECOVERY_IN_PROGRESS` alert: TWAI controller is undergoing bus recovery.
         pub fn recovery_in_progress(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_RECOVERY_IN_PROGRESS,
             }
         }
 
-        // Enable the `BUS_RECOVERED` alert: TWAI controller has successfully completed bus recovery.
+        /// Enable the `BUS_RECOVERED` alert: TWAI controller has successfully completed bus recovery.
         pub fn bus_recovered(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_BUS_RECOVERED,
             }
         }
 
-        // Enable the `ARB_LOST` alert: The previous transmission lost arbitration.
+        /// Enable the `ARB_LOST` alert: The previous transmission lost arbitration.
         pub fn arb_lost(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_ARB_LOST,
             }
         }
 
-        // Enable the `ABOVE_ERR_WARN` alert: One of the error counters have exceeded the error warning limit.
+        /// Enable the `ABOVE_ERR_WARN` alert: One of the error counters have exceeded the error warning limit.
         pub fn above_err_warn(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_ABOVE_ERR_WARN,
             }
         }
 
-        // Enable the `BUS_ERROR` alert: A (Bit, Stuff, CRC, Form, ACK) error has occurred on the bus.
+        /// Enable the `BUS_ERROR` alert: A (Bit, Stuff, CRC, Form, ACK) error has occurred on the bus.
         pub fn bus_error(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_BUS_ERROR,
             }
         }
 
-        // Enable the `TX_FAILED` alert: The previous transmission has failed (for single shot transmission).
+        /// Enable the `TX_FAILED` alert: The previous transmission has failed (for single shot transmission).
         pub fn tx_failed(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_TX_FAILED,
             }
         }
 
-        // Enable the `RX_QUEUE_FULL` alert: The RX queue is full causing a frame to be lost.
+        /// Enable the `RX_QUEUE_FULL` alert: The RX queue is full causing a frame to be lost.
         pub fn rx_queue_full(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_RX_QUEUE_FULL,
             }
         }
 
-        // Enable the `ERR_PASS` alert: TWAI controller has become error passive.
+        /// Enable the `ERR_PASS` alert: TWAI controller has become error passive.
         pub fn err_pass(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_ERR_PASS,
             }
         }
 
-        // Enable the `BUS_OFF` alert: Bus-off condition occurred. TWAI controller can no longer influence bus.
+        /// Enable the `BUS_OFF` alert: Bus-off condition occurred. TWAI controller can no longer influence bus.
         pub fn bus_off(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_BUS_OFF,
             }
         }
 
-        // Enable the `RX_FIFO_OVERRUN` alert: An RX FIFO overrun has occurred.
+        /// Enable the `RX_FIFO_OVERRUN` alert: An RX FIFO overrun has occurred.
         pub fn rx_fifo_overrun(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_RX_FIFO_OVERRUN,
             }
         }
 
-        // Enable the `TX_RETRIED` alert: An message transmission was cancelled and retried due to an errata workaround.
+        /// Enable the `TX_RETRIED` alert: An message transmission was cancelled and retried due to an errata workaround.
         pub fn tx_retried(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_TX_RETRIED,
             }
         }
 
-        // Enable the `PERIPH_RESET` alert: The TWAI controller was reset.
+        /// Enable the `PERIPH_RESET` alert: The TWAI controller was reset.
         pub fn periph_reset(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_PERIPH_RESET,
             }
         }
 
-        // Enable all alerts.
+        /// Enable all alerts.
         pub fn all(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_ALL,
             }
         }
 
-        // Enable alert logging when they occur. Note that logging from the ISR is disabled if CONFIG_TWAI_ISR_IN_IRAM is enabled.
+        /// Enable alert logging when they occur. Note that logging from the ISR is disabled if CONFIG_TWAI_ISR_IN_IRAM is enabled.
         pub fn and_log(self) -> Self {
             Self {
                 value: self.value | Self::TWAI_ALERT_AND_LOG,


### PR DESCRIPTION
With this PR, I’d like to add the possibility to specify different operation modes and alert configuration for `CanDriver`.