### PR TITLE
Improvement: Set LedcTimerDriver frequency

### DIFF
--- a/src/ledc.rs
+++ b/src/ledc.rs
@@ -145,6 +145,12 @@ impl<'d> LedcTimerDriver<'d> {
         Ok(())
     }
 
+    /// Set the frequency of the timer.
+    pub fn set_frequency(&mut self, frequency: Hertz) -> Result<(), EspError> {
+        esp!(unsafe { ledc_set_freq(self.speed_mode.into(), self.timer, frequency.into()) })?;
+        Ok(())
+    }
+
     fn reset(&mut self) -> Result<(), EspError> {
         esp!(unsafe { ledc_timer_rst(self.speed_mode.into(), self.timer()) })?;
         Ok(())

--- a/src/ledc.rs
+++ b/src/ledc.rs
@@ -147,7 +147,9 @@ impl<'d> LedcTimerDriver<'d> {
 
     /// Set the frequency of the timer.
     pub fn set_frequency(&mut self, frequency: Hertz) -> Result<(), EspError> {
-        esp!(unsafe { ledc_set_freq(self.speed_mode.into(), self.timer.into(), frequency.into()) })?;
+        esp!(unsafe {
+            ledc_set_freq(self.speed_mode.into(), self.timer.into(), frequency.into())
+        })?;
         Ok(())
     }
 

--- a/src/ledc.rs
+++ b/src/ledc.rs
@@ -33,6 +33,7 @@ use esp_idf_sys::*;
 use crate::gpio::OutputPin;
 use crate::peripheral::Peripheral;
 use crate::task::CriticalSection;
+use crate::units::*;
 
 pub use chip::*;
 
@@ -47,7 +48,6 @@ static FADE_FUNC_INSTALLED_CS: CriticalSection = CriticalSection::new();
 /// Types for configuring the LED Control peripheral
 pub mod config {
     use super::*;
-    use crate::units::*;
 
     pub use chip::Resolution;
 
@@ -147,7 +147,7 @@ impl<'d> LedcTimerDriver<'d> {
 
     /// Set the frequency of the timer.
     pub fn set_frequency(&mut self, frequency: Hertz) -> Result<(), EspError> {
-        esp!(unsafe { ledc_set_freq(self.speed_mode.into(), self.timer, frequency.into()) })?;
+        esp!(unsafe { ledc_set_freq(self.speed_mode.into(), self.timer.into(), frequency.into()) })?;
         Ok(())
     }
 


### PR DESCRIPTION
Hi there,

This proposed minor addition gives the ability to set the frequency of an LedcTimerDriver after it has been created by calling the esp-idf function [ledc_set_freq](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/ledc.html#_CPPv413ledc_set_freq11ledc_mode_t12ledc_timer_t8uint32_t).  I've found it quite helpful for a quick and dirty PWM controller for motor drivers and such. 

I wasn't sure what to do about the frequency of the TimerConfig object since the LedcTimerDriver seems to be where you control the timer but I am open to suggestions 😊. It has been tested on an ESP32-S3

Please let me know if you need anything else before reviewing the request.