### PR TITLE
Make PinDriver no longer reset pin on drop.  Add public reset_pin function to PinDriver

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1038,8 +1038,15 @@ impl<'d, T: Pin, MODE> PinDriver<'d, T, MODE> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'d, T: Pin, MODE> Drop for PinDriver<'d, T, MODE> {
     fn drop(&mut self) {
+        unsafe { unsubscribe_pin(self.pin.pin()) }.unwrap();
+    }
+}
+
+impl<'d, T: Pin, MODE> PinDriver<'d, T, MODE> {
+    pub fn reset(&mut self) {
         unsafe { reset_pin(self.pin.pin(), gpio_mode_t_GPIO_MODE_DISABLE) }.unwrap();
     }
 }


### PR DESCRIPTION
This makes PinDriver no longer reset and disable a pin on drop, solving issue #217.
A public function to provide the reset functionality is added as well.
