### PR TITLE
Fix cs keep active#99

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -32,7 +32,7 @@
 
 use core::borrow::{Borrow, BorrowMut};
 use core::cell::UnsafeCell;
-use core::cmp::{max, min, Ordering};
+use core::cmp::{min, Ordering};
 use core::marker::PhantomData;
 use core::ptr;
 
@@ -266,7 +266,7 @@ impl<T> SpiBusDriver<T> {
     }
 
     pub fn read(&mut self, words: &mut [u8]) -> Result<(), EspError> {
-        let mut it = words.chunks_mut(self.trans_len).into_iter().peekable();
+        let mut it = words.chunks_mut(self.trans_len).peekable();
         while let Some(read_chunk) = it.next() {
             self.polling_transmit(
                 read_chunk.as_mut_ptr(),
@@ -281,7 +281,7 @@ impl<T> SpiBusDriver<T> {
     }
 
     pub fn write(&mut self, words: &[u8]) -> Result<(), EspError> {
-        let mut it = words.chunks(self.trans_len).into_iter().peekable();
+        let mut it = words.chunks(self.trans_len).peekable();
         while let Some(write_chunk) = it.next() {
             self.polling_transmit(
                 ptr::null_mut(),
@@ -310,7 +310,7 @@ impl<T> SpiBusDriver<T> {
         let common_read = read[0..common_length].chunks_mut(self.trans_len);
         let common_write = write[0..common_length].chunks(self.trans_len);
 
-        let mut it = common_read.zip(common_write).into_iter().peekable();
+        let mut it = common_read.zip(common_write).peekable();
         while let Some((read_chunk, write_chunk)) = it.next() {
             self.polling_transmit(
                 read_chunk.as_mut_ptr(),
@@ -337,7 +337,7 @@ impl<T> SpiBusDriver<T> {
     }
 
     pub fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), EspError> {
-        let mut it = words.chunks_mut(self.trans_len).into_iter().peekable();
+        let mut it = words.chunks_mut(self.trans_len).peekable();
         while let Some(chunk) = it.next() {
             let ptr = chunk.as_mut_ptr();
             let len = chunk.len();

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -266,13 +266,16 @@ impl<T> SpiBusDriver<T> {
     }
 
     pub fn read(&mut self, words: &mut [u8]) -> Result<(), EspError> {
-
         let mut it = words.chunks_mut(self.trans_len).into_iter().peekable();
         while let Some(read_chunk) = it.next() {
-            self.polling_transmit(read_chunk.as_mut_ptr(), ptr::null(), read_chunk.len(), read_chunk.len(), it.peek().is_some())?;
-
+            self.polling_transmit(
+                read_chunk.as_mut_ptr(),
+                ptr::null(),
+                read_chunk.len(),
+                read_chunk.len(),
+                it.peek().is_some(),
+            )?;
         }
-        
 
         Ok(())
     }
@@ -280,7 +283,13 @@ impl<T> SpiBusDriver<T> {
     pub fn write(&mut self, words: &[u8]) -> Result<(), EspError> {
         let mut it = words.chunks(self.trans_len).into_iter().peekable();
         while let Some(write_chunk) = it.next() {
-            self.polling_transmit(ptr::null_mut(), write_chunk.as_ptr(), write_chunk.len(), 0, it.peek().is_some())?;
+            self.polling_transmit(
+                ptr::null_mut(),
+                write_chunk.as_ptr(),
+                write_chunk.len(),
+                0,
+                it.peek().is_some(),
+            )?;
         }
 
         Ok(())
@@ -289,22 +298,26 @@ impl<T> SpiBusDriver<T> {
     // Note 1 : If read and write buffer are not of the same length it will
     // first transfer the common length and then (seperatly aliend) the remaining buffer.
     // Note 2: Expect a delaytime between every internally splitted (64byte or remainder) package
+
+    // Note 3: In Half-Duplex & Half-3-Duplex Mode data will be split in 64 byte write / read sections
+    // example write: [u8;96] - read [u8; 160]
+    // package 1: write 64, read 64 -> package 2: write 32 read:32 -> package 3: write 0, read 64
+    // Note 3.1 Note that the first "package" is an 128 byte clock out while the later are respectivly 64 byte
+
     pub fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), EspError> {
+        let more_chunks = read.len() != write.len();
         let common_length = min(read.len(), write.len());
         let common_read = read[0..common_length].chunks_mut(self.trans_len);
         let common_write = write[0..common_length].chunks(self.trans_len);
 
         let mut it = common_read.zip(common_write).into_iter().peekable();
-        while let Some((read_chunk,write_chunk)) = it.next() {
-            // here read chunk_len and write_chunk_len should always be the same length
-            // implicitly because of commen_length
-            let common_chunk_len = max(read_chunk.len(),write_chunk.len());
+        while let Some((read_chunk, write_chunk)) = it.next() {
             self.polling_transmit(
                 read_chunk.as_mut_ptr(),
                 write_chunk.as_ptr(),
-                common_chunk_len,
-                common_chunk_len,
-                it.peek().is_some(),
+                read_chunk.len(), //read/write chunk implicitly always same length because of commen_length
+                read_chunk.len(),
+                it.peek().is_some() || more_chunks,
             )?;
         }
 
@@ -325,7 +338,7 @@ impl<T> SpiBusDriver<T> {
 
     pub fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), EspError> {
         let mut it = words.chunks_mut(self.trans_len).into_iter().peekable();
-        while let Some(chunk) =  it.next() {
+        while let Some(chunk) = it.next() {
             let ptr = chunk.as_mut_ptr();
             let len = chunk.len();
             self.polling_transmit(ptr, ptr, len, len, it.peek().is_some())?;


### PR DESCRIPTION
Motivation: Remove the finish() call using "empty" polling_transmit . This creates a lot of overhead and comes with wired problems sending not really an empty transmit rather often sends the data just two times in a row. 

To de assert the CS line correctly after an polling_transmit the transfer functions now keep track of it by themself.