### PR TITLE
Add CAN intr flags to config

### DIFF
--- a/src/can.rs
+++ b/src/can.rs
@@ -441,6 +441,7 @@ pub mod config {
         pub rx_queue_len: u32,
         pub mode: Mode,
         pub alerts: Alerts,
+        pub intr_flags: i32,
     }
 
     impl Config {
@@ -448,6 +449,7 @@ pub mod config {
             Config {
                 tx_queue_len: 5,
                 rx_queue_len: 5,
+                intr_flags: ESP_INTR_FLAG_LEVEL1 as i32,
                 ..Default::default()
             }
         }
@@ -483,6 +485,11 @@ pub mod config {
             self.alerts = alerts;
             self
         }
+
+        pub fn intr_flags(mut self, flags: i32) -> Self {
+            self.intr_flags = flags;
+            self
+        }
     }
 }
 
@@ -510,7 +517,7 @@ impl<'d> CanDriver<'d> {
             rx_queue_len: config.rx_queue_len,
             alerts_enabled: config.alerts.into(),
             clkout_divider: 0,
-            intr_flags: ESP_INTR_FLAG_LEVEL1 as i32,
+            intr_flags: config.intr_flags,
         };
 
         let timing_config = config.timing.into();

--- a/src/can.rs
+++ b/src/can.rs
@@ -51,6 +51,8 @@ pub type CanConfig = config::Config;
 pub mod config {
     use esp_idf_sys::*;
 
+    use crate::interrupt::IntrFlags;
+
     /// CAN timing
     #[derive(Debug, Copy, Clone, Eq, PartialEq)]
     pub enum Timing {
@@ -160,68 +162,6 @@ pub mod config {
     impl Default for Timing {
         fn default() -> Self {
             Self::B500K
-        }
-    }
-
-    /// Interrupt allocation flags.
-    /// These flags can be used to specify which interrupt qualities the code calling esp_intr_alloc* needs.
-    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-    pub enum IntrFlags {
-        // Accept a Level 1 interrupt vector (lowest priority)
-        Level1,
-        // Accept a Level 2 interrupt vector.
-        Level2,
-        // Accept a Level 3 interrupt vector.
-        Level3,
-        // Accept a Level 4 interrupt vector.
-        Level4,
-        // Accept a Level 5 interrupt vector.
-        Level5,
-        // Accept a Level 6 interrupt vector.
-        Level6,
-        // Accept a Level 7 interrupt vector (highest priority)
-        Nmi,
-        // Interrupt can be shared between ISRs.
-        Shared,
-        // Edge-triggered interrupt.
-        Edge,
-        // ISR can be called if cache is disabled.
-        // Must be used with a proper option *_ISR_IN_IRAM in SDKCONFIG
-        Iram,
-        // Return with this interrupt disabled.
-        IntrDisabled,
-        // Low and medium prio interrupts. These can be handled in C.
-        LowMed,
-        // High level interrupts. Need to be handled in assembly.
-        High,
-        // Mask for all level flags.
-        LevelMask,
-    }
-
-    impl From<IntrFlags> for u32 {
-        fn from(flag: IntrFlags) -> Self {
-            match flag {
-                IntrFlags::Level1 => esp_idf_sys::ESP_INTR_FLAG_LEVEL1,
-                IntrFlags::Level2 => esp_idf_sys::ESP_INTR_FLAG_LEVEL2,
-                IntrFlags::Level3 => esp_idf_sys::ESP_INTR_FLAG_LEVEL3,
-                IntrFlags::Level4 => esp_idf_sys::ESP_INTR_FLAG_LEVEL4,
-                IntrFlags::Level5 => esp_idf_sys::ESP_INTR_FLAG_LEVEL5,
-                IntrFlags::Level6 => esp_idf_sys::ESP_INTR_FLAG_LEVEL6,
-                IntrFlags::Nmi => esp_idf_sys::ESP_INTR_FLAG_NMI,
-                IntrFlags::Shared => esp_idf_sys::ESP_INTR_FLAG_SHARED,
-                IntrFlags::Edge => esp_idf_sys::ESP_INTR_FLAG_EDGE,
-                IntrFlags::Iram => esp_idf_sys::ESP_INTR_FLAG_IRAM,
-                IntrFlags::IntrDisabled => esp_idf_sys::ESP_INTR_FLAG_INTRDISABLED,
-                IntrFlags::LowMed => esp_idf_sys::ESP_INTR_FLAG_LOWMED,
-                IntrFlags::High => esp_idf_sys::ESP_INTR_FLAG_HIGH,
-                IntrFlags::LevelMask => esp_idf_sys::ESP_INTR_FLAG_LEVELMASK,
-            }
-        }
-    }
-
-    impl Default for IntrFlags {
-        fn default() -> Self {
-            Self::Level1
         }
     }
 

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -4,6 +4,68 @@ use esp_idf_sys::*;
 
 pub(crate) static CS: IsrCriticalSection = IsrCriticalSection::new();
 
+/// Interrupt allocation flags.
+/// These flags can be used to specify which interrupt qualities the code calling esp_intr_alloc* needs.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum IntrFlags {
+    // Accept a Level 1 interrupt vector (lowest priority)
+    Level1,
+    // Accept a Level 2 interrupt vector.
+    Level2,
+    // Accept a Level 3 interrupt vector.
+    Level3,
+    // Accept a Level 4 interrupt vector.
+    Level4,
+    // Accept a Level 5 interrupt vector.
+    Level5,
+    // Accept a Level 6 interrupt vector.
+    Level6,
+    // Accept a Level 7 interrupt vector (highest priority)
+    Nmi,
+    // Interrupt can be shared between ISRs.
+    Shared,
+    // Edge-triggered interrupt.
+    Edge,
+    // ISR can be called if cache is disabled.
+    // Must be used with a proper option *_ISR_IN_IRAM in SDKCONFIG
+    Iram,
+    // Return with this interrupt disabled.
+    IntrDisabled,
+    // Low and medium prio interrupts. These can be handled in C.
+    LowMed,
+    // High level interrupts. Need to be handled in assembly.
+    High,
+    // Mask for all level flags.
+    LevelMask,
+}
+
+impl From<IntrFlags> for u32 {
+    fn from(flag: IntrFlags) -> Self {
+        match flag {
+            IntrFlags::Level1 => esp_idf_sys::ESP_INTR_FLAG_LEVEL1,
+            IntrFlags::Level2 => esp_idf_sys::ESP_INTR_FLAG_LEVEL2,
+            IntrFlags::Level3 => esp_idf_sys::ESP_INTR_FLAG_LEVEL3,
+            IntrFlags::Level4 => esp_idf_sys::ESP_INTR_FLAG_LEVEL4,
+            IntrFlags::Level5 => esp_idf_sys::ESP_INTR_FLAG_LEVEL5,
+            IntrFlags::Level6 => esp_idf_sys::ESP_INTR_FLAG_LEVEL6,
+            IntrFlags::Nmi => esp_idf_sys::ESP_INTR_FLAG_NMI,
+            IntrFlags::Shared => esp_idf_sys::ESP_INTR_FLAG_SHARED,
+            IntrFlags::Edge => esp_idf_sys::ESP_INTR_FLAG_EDGE,
+            IntrFlags::Iram => esp_idf_sys::ESP_INTR_FLAG_IRAM,
+            IntrFlags::IntrDisabled => esp_idf_sys::ESP_INTR_FLAG_INTRDISABLED,
+            IntrFlags::LowMed => esp_idf_sys::ESP_INTR_FLAG_LOWMED,
+            IntrFlags::High => esp_idf_sys::ESP_INTR_FLAG_HIGH,
+            IntrFlags::LevelMask => esp_idf_sys::ESP_INTR_FLAG_LEVELMASK,
+        }
+    }
+}
+
+impl Default for IntrFlags {
+    fn default() -> Self {
+        Self::Level1
+    }
+}
+
 /// Returns true if the currently active core is executing an ISR request
 #[inline(always)]
 #[link_section = ".iram1.interrupt_active"]


### PR DESCRIPTION
I run into an issue that is described here: [Running out of interrupts](https://esp32developer.com/programming-in-c-c/interrupts/running-out-of-interrupts). With this pull request, I would like to add interrupt flags to the config then I can use custom interrupt flags for the CAN driver.