### PR TITLE
Error with struct ledc_timer_config_t field deconfigure in ESP-IDF v5.1

### DIFF
--- a/src/ledc.rs
+++ b/src/ledc.rs
@@ -126,10 +126,7 @@ impl<'d> LedcTimerDriver<'d> {
             clk_cfg: ledc_clk_cfg_t_LEDC_AUTO_CLK,
             #[cfg(not(any(esp_idf_version_major = "4", esp_idf_version_minor = "0")))]
             clk_cfg: soc_periph_ledc_clk_src_legacy_t_LEDC_AUTO_CLK,
-            #[cfg(not(any(
-                esp_idf_version_major = "4",
-                all(esp_idf_version_major = "5", esp_idf_version_minor = "0")
-            )))]
+            #[cfg(not(any(esp_idf_version_major = "4", all(esp_idf_version_major = "5"),)))]
             deconfigure: false,
         };
 


### PR DESCRIPTION
When using ESP-IDF v5.1, the compilation throws an error with the following message: ```error[E0560]: struct esp_idf_sys::ledc_timer_config_t has no field named deconfigure```. This error occurs because the field deconfigure is not available in the ledc_timer_config_t struct in ESP-IDF v5.1. This pull request fixes the issue.