### PR TITLE
Add safe abstractions to CRC functions in ESP ROM

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub mod prelude;
 pub mod reset;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub mod rmt;
+pub mod rom;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub mod spi;
 #[cfg(not(feature = "riscv-ulp-hal"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub mod prelude;
 pub mod reset;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub mod rmt;
+#[cfg(not(feature = "riscv-ulp-hal"))]
 pub mod rom;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub mod spi;

--- a/src/rom/crc.rs
+++ b/src/rom/crc.rs
@@ -1,0 +1,104 @@
+//! Cyclic Redundancy Check
+//! 
+//! These are safe abstractions to the CRC functions in the ESP32 ROM.
+//! Some chips may not include all of these functions so they will be compiled
+//! into the program binary in those cases.
+//! 
+//! # Parameters
+//! 
+//! The ROM provides the following polynomials for each CRC width:
+//! 
+//! | CRC Width | Polynomial |
+//! | --------- | ---------- |
+//! | CRC-8     | 0x07       |
+//! | CRC-16    | 0x1021     |
+//! | CRC-32    | 0x0411db7  |
+//! 
+//! The "big-endian" `*_be()` functions are left-shifting algorithms to be used
+//! when input and output reflection are **not** needed. If input and output
+//! reflection **are** needed, the right-shifting "little-endian" `*_le()`
+//! functions should be used.
+//! 
+//! These functions are designed to compute a CRC over a single buffer or as an
+//! ongoing calculation over multiple buffers. To do this, the initial value
+//! passed in and the final value returned are one's complemented.
+//! 
+//! ```
+//! // CRC-32/MPEG-2
+//! const CRC_INITIAL = 0xffffffff; // "init" or "xorin" of all ones
+//! let mut crc = crc32_be(!CRC_INITIAL, &data0); // start
+//! crc = crc32_be(crc, &data1);
+//! crc = !crc32_be(crc, &data2); // finish
+//! ```
+//! 
+//! # Examples
+//! 
+//! A catalogue of these parameters can be found at
+//! <https://reveng.sourceforge.io/crc-catalogue/all.htm>
+//! 
+//! CRC-32/ISO-HDLC poly=0x04c11db7 init=0xffffffff refin=true refout=true xorout=0xffffffff
+//! ```
+//! let crc = crc32_le(!0xffffffff, &data);
+//! ```
+//! 
+//! CRC-32/BZIP2 poly=0x04c11db7 init=0xffffffff refin=false refout=false xorout=0xffffffff
+//! ```
+//! let crc = crc32_be(!0xffffffff, &data);
+//! ```
+//! 
+//! CRC-32/MPEG-2 poly=0x04c11db7 init=0xffffffff refin=false refout=false xorout=0x00000000
+//! ```
+//! let crc = !crc32_be(!0xffffffff, &data);
+//! ```
+//! 
+//! CRC-32/CKSUM poly=0x04c11db7 init=0x00000000 refin=false refout=false xorout=0xffffffff
+//! ```
+//! let crc = crc32_be(!0, &data);
+//! ```
+//! 
+//! CRC-16/KERMIT poly=0x1021 init=0x0000 refin=true refout=true xorout=0x0000
+//! ```
+//! let crc = !crc16_le(!0, data);
+//! ```
+
+use esp_idf_sys::*;
+
+// SAFETY: These functions are all implemented as table lookups. No locking is
+// needed to access them, they are all referentially transparent, and the size
+// and alignment of `usize` and `u32` are identical on all ESP32 chips.
+
+/// Right-shifting CRC-32 with polynomial 0x0411db7
+#[inline(always)]
+pub fn crc32_le(crc: u32, buf: &[u8]) -> u32 {
+    unsafe { esp_rom_crc32_le(crc, buf.as_ptr(), buf.len() as u32) }
+}
+
+/// Left-shifting CRC-32 with polynomial 0x0411db7
+#[inline(always)]
+pub fn crc32_be(crc: u32, buf: &[u8]) -> u32 {
+    unsafe { esp_rom_crc32_be(crc, buf.as_ptr(), buf.len() as u32) }
+}
+
+/// Right-shifting CRC-32 with polynomial 0x1021
+#[inline(always)]
+pub fn crc16_le(crc: u16, buf: &[u8]) -> u16 {
+    unsafe { esp_rom_crc16_le(crc, buf.as_ptr(), buf.len() as u32) }
+}
+
+/// Left-shifting CRC-32 with polynomial 0x1021
+#[inline(always)]
+pub fn crc16_be(crc: u16, buf: &[u8]) -> u16 {
+    unsafe { esp_rom_crc16_be(crc, buf.as_ptr(), buf.len() as u32) }
+}
+
+/// Right-shifting CRC-8 with polynomial 0x07
+#[inline(always)]
+pub fn crc8_le(crc: u8, buf: &[u8]) -> u8 {
+    unsafe { esp_rom_crc8_le(crc, buf.as_ptr(), buf.len() as u32) }
+}
+
+/// Left-shifting CRC-8 with polynomial 0x07
+#[inline(always)]
+pub fn crc8_be(crc: u8, buf: &[u8]) -> u8 {
+    unsafe { esp_rom_crc8_be(crc, buf.as_ptr(), buf.len() as u32) }
+}

--- a/src/rom/crc.rs
+++ b/src/rom/crc.rs
@@ -1,28 +1,28 @@
 //! Cyclic Redundancy Check
-//! 
+//!
 //! These are safe abstractions to the CRC functions in the ESP32 ROM.
 //! Some chips may not include all of these functions so they will be compiled
 //! into the program binary in those cases.
-//! 
+//!
 //! # Parameters
-//! 
+//!
 //! The ROM provides the following polynomials for each CRC width:
-//! 
+//!
 //! | CRC Width | Polynomial |
 //! | --------- | ---------- |
 //! | CRC-8     | 0x07       |
 //! | CRC-16    | 0x1021     |
 //! | CRC-32    | 0x0411db7  |
-//! 
+//!
 //! The "big-endian" `*_be()` functions are left-shifting algorithms to be used
 //! when input and output reflection are **not** needed. If input and output
 //! reflection **are** needed, the right-shifting "little-endian" `*_le()`
 //! functions should be used.
-//! 
+//!
 //! These functions are designed to compute a CRC over a single buffer or as an
 //! ongoing calculation over multiple buffers. To do this, the initial value
 //! passed in and the final value returned are one's complemented.
-//! 
+//!
 //! ```
 //! // CRC-32/MPEG-2
 //! const CRC_INITIAL = 0xffffffff; // "init" or "xorin" of all ones
@@ -30,32 +30,32 @@
 //! crc = crc32_be(crc, &data1);
 //! crc = !crc32_be(crc, &data2); // finish
 //! ```
-//! 
+//!
 //! # Examples
-//! 
+//!
 //! A catalogue of these parameters can be found at
 //! <https://reveng.sourceforge.io/crc-catalogue/all.htm>
-//! 
+//!
 //! CRC-32/ISO-HDLC poly=0x04c11db7 init=0xffffffff refin=true refout=true xorout=0xffffffff
 //! ```
 //! let crc = crc32_le(!0xffffffff, &data);
 //! ```
-//! 
+//!
 //! CRC-32/BZIP2 poly=0x04c11db7 init=0xffffffff refin=false refout=false xorout=0xffffffff
 //! ```
 //! let crc = crc32_be(!0xffffffff, &data);
 //! ```
-//! 
+//!
 //! CRC-32/MPEG-2 poly=0x04c11db7 init=0xffffffff refin=false refout=false xorout=0x00000000
 //! ```
 //! let crc = !crc32_be(!0xffffffff, &data);
 //! ```
-//! 
+//!
 //! CRC-32/CKSUM poly=0x04c11db7 init=0x00000000 refin=false refout=false xorout=0xffffffff
 //! ```
 //! let crc = crc32_be(!0, &data);
 //! ```
-//! 
+//!
 //! CRC-16/KERMIT poly=0x1021 init=0x0000 refin=true refout=true xorout=0x0000
 //! ```
 //! let crc = !crc16_le(!0, data);

--- a/src/rom/mod.rs
+++ b/src/rom/mod.rs
@@ -1,0 +1,6 @@
+//! ESP ROM libraries
+//! 
+//! Safe abstractions to the additional libraries provided in the ESP's
+//! read-only memory.
+
+pub mod crc;

--- a/src/rom/mod.rs
+++ b/src/rom/mod.rs
@@ -1,5 +1,5 @@
 //! ESP ROM libraries
-//! 
+//!
 //! Safe abstractions to the additional libraries provided in the ESP's
 //! read-only memory.
 


### PR DESCRIPTION
This is the safe CRC abstraction over the newly merged esp-rs/esp-idf-sys@4ffb8838c8bb9e76c43ca021fdb9b5050340d036

I created the `rom` module to put commonly available ROM libraries, such as CRC. MD5 could be next. Since these libraries rely on the bindings provided by esp-idf-sys but are only on ESP32 chips they belong here in esp-idf-hal and not esp-idf-svc.

Test code is below or at [my repository](https://github.com/jordanhalase/test-esp-idf-hal-crc/blob/master/src/main.rs)

```Rust
use esp_idf_sys as _; // For binstart

use esp_idf_hal::rom::crc;

fn main() {
    esp_idf_sys::link_patches();

    let data = "123456789";

    loop {
        let crc_hdlc = crc::crc32_le(!0xffffffff, data.as_ref());
        let crc_bzip2 = crc::crc32_be(!0xffffffff, data.as_ref());
        let crc_mpeg2 = !crc::crc32_be(!0xffffffff, data.as_ref());
        let crc_cksum = crc::crc32_be(!0, data.as_ref());
        let crc_kermit = !crc::crc16_le(!0, data.as_ref());
        let crc_genibus = crc::crc16_be(!0xffff, data.as_ref());
        let crc_rohc = !crc::crc8_le(!0xff, data.as_ref());
        let crc_smbus = !crc::crc8_be(!0, data.as_ref());

        assert_eq!(crc_hdlc, 0xcbf43926);
        assert_eq!(crc_bzip2, 0xfc891918);
        assert_eq!(crc_mpeg2, 0x0376e6e7);
        assert_eq!(crc_cksum, 0x765e7680);
        assert_eq!(crc_kermit, 0x2189);
        assert_eq!(crc_genibus, 0xd64e);
        assert_eq!(crc_rohc, 0xd0);
        assert_eq!(crc_smbus, 0xf4);

        println!("{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x}",
            crc_hdlc, crc_bzip2, crc_mpeg2, crc_cksum, crc_kermit, crc_genibus, crc_rohc, crc_smbus);

        std::thread::sleep(std::time::Duration::from_millis(5000));
    }
}
```