### PR TITLE
Try retransmission of CAN frames by default

### DIFF
--- a/src/can.rs
+++ b/src/can.rs
@@ -663,7 +663,6 @@ impl Frame {
             let mut flags = twai_message_t__bindgen_ty_1::default();
 
             // set bits in an union
-            unsafe { flags.__bindgen_anon_1.set_ss(1) };
             if extended {
                 unsafe { flags.__bindgen_anon_1.set_extd(1) };
             }
@@ -692,7 +691,6 @@ impl Frame {
 
             // set bits in an union
             unsafe { flags.__bindgen_anon_1.set_rtr(1) };
-            unsafe { flags.__bindgen_anon_1.set_ss(1) };
             if extended {
                 unsafe { flags.__bindgen_anon_1.set_extd(1) };
             }


### PR DESCRIPTION
By default the [single shot](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/twai.html#message-fields-and-flags) flag is set for all CAN frames. Therefore the esp will only try to send each frame once. This is no problem if there is only ever one device sending messages on the bus. But it can lead to "dropped" frames with multiple transmitting devices, as a failed arbitration (i.e. another device sends a frame with a higher priority id at the same time) is not that uncommon. There might be situations where single shot frames can be useful; but in my opinion the default behaviour should be that retransmission is tried automatically.

This pull request simply removes the lines setting the single shot flag in the frame constructors.

Maybe we should add some methods for getting and setting this flag (and maybe others like `TWAI_MSG_FLAG_SELF`). I can also help implement those if necessary ;)