### PR TITLE
Fix typos in rom::crc docs

### DIFF
--- a/src/rom/crc.rs
+++ b/src/rom/crc.rs
@@ -8,11 +8,11 @@
 //!
 //! The ROM provides the following polynomials for each CRC width:
 //!
-//! | CRC Width | Polynomial |
-//! | --------- | ---------- |
-//! | CRC-8     | 0x07       |
-//! | CRC-16    | 0x1021     |
-//! | CRC-32    | 0x0411db7  |
+//! | CRC Width | Polynomial  |
+//! | --------- | ----------- |
+//! | CRC-8     | 0x07        |
+//! | CRC-16    | 0x1021      |
+//! | CRC-32    | 0x04c11db7  |
 //!
 //! The "big-endian" `*_be()` functions are left-shifting algorithms to be used
 //! when input and output reflection are **not** needed. If input and output
@@ -37,28 +37,33 @@
 //! <https://reveng.sourceforge.io/crc-catalogue/all.htm>
 //!
 //! CRC-32/ISO-HDLC poly=0x04c11db7 init=0xffffffff refin=true refout=true xorout=0xffffffff
+//!
 //! ```
 //! let crc = crc32_le(!0xffffffff, &data);
 //! ```
 //!
 //! CRC-32/BZIP2 poly=0x04c11db7 init=0xffffffff refin=false refout=false xorout=0xffffffff
+//!
 //! ```
 //! let crc = crc32_be(!0xffffffff, &data);
 //! ```
 //!
 //! CRC-32/MPEG-2 poly=0x04c11db7 init=0xffffffff refin=false refout=false xorout=0x00000000
+//!
 //! ```
 //! let crc = !crc32_be(!0xffffffff, &data);
 //! ```
 //!
 //! CRC-32/CKSUM poly=0x04c11db7 init=0x00000000 refin=false refout=false xorout=0xffffffff
+//!
 //! ```
 //! let crc = crc32_be(!0, &data);
 //! ```
 //!
 //! CRC-16/KERMIT poly=0x1021 init=0x0000 refin=true refout=true xorout=0x0000
+//!
 //! ```
-//! let crc = !crc16_le(!0, data);
+//! let crc = !crc16_le(!0, &data);
 //! ```
 
 use esp_idf_sys::*;
@@ -67,25 +72,25 @@ use esp_idf_sys::*;
 // needed to access them, they are all referentially transparent, and the size
 // and alignment of `usize` and `u32` are identical on all ESP32 chips.
 
-/// Right-shifting CRC-32 with polynomial 0x0411db7
+/// Right-shifting CRC-32 with polynomial 0x04c11db7
 #[inline(always)]
 pub fn crc32_le(crc: u32, buf: &[u8]) -> u32 {
     unsafe { esp_rom_crc32_le(crc, buf.as_ptr(), buf.len() as u32) }
 }
 
-/// Left-shifting CRC-32 with polynomial 0x0411db7
+/// Left-shifting CRC-32 with polynomial 0x04c11db7
 #[inline(always)]
 pub fn crc32_be(crc: u32, buf: &[u8]) -> u32 {
     unsafe { esp_rom_crc32_be(crc, buf.as_ptr(), buf.len() as u32) }
 }
 
-/// Right-shifting CRC-32 with polynomial 0x1021
+/// Right-shifting CRC-16 with polynomial 0x1021
 #[inline(always)]
 pub fn crc16_le(crc: u16, buf: &[u8]) -> u16 {
     unsafe { esp_rom_crc16_le(crc, buf.as_ptr(), buf.len() as u32) }
 }
 
-/// Left-shifting CRC-32 with polynomial 0x1021
+/// Left-shifting CRC-16 with polynomial 0x1021
 #[inline(always)]
 pub fn crc16_be(crc: u16, buf: &[u8]) -> u16 {
     unsafe { esp_rom_crc16_be(crc, buf.as_ptr(), buf.len() as u32) }


### PR DESCRIPTION
Fixed some typos in the docs. No code change.