### PR TITLE
pconfig does not need to be mut.

### DIFF
--- a/examples/pcnt_i64_encoder.rs
+++ b/examples/pcnt_i64_encoder.rs
@@ -83,7 +83,7 @@ mod encoder {
                 PcntChannel::Channel0,
                 PinIndex::Pin0,
                 PinIndex::Pin1,
-                &mut PcntChannelConfig {
+                &PcntChannelConfig {
                     lctrl_mode: PcntControlMode::Reverse,
                     hctrl_mode: PcntControlMode::Keep,
                     pos_mode: PcntCountMode::Decrement,
@@ -96,7 +96,7 @@ mod encoder {
                 PcntChannel::Channel1,
                 PinIndex::Pin1,
                 PinIndex::Pin0,
-                &mut PcntChannelConfig {
+                &PcntChannelConfig {
                     lctrl_mode: PcntControlMode::Reverse,
                     hctrl_mode: PcntControlMode::Keep,
                     pos_mode: PcntCountMode::Increment,


### PR DESCRIPTION
This fixes a clippy issue from rust-analyzer that's been sitting in VSCode's problems pane for a while.