### PR TITLE
🚸 add simple timer example with task notify

### DIFF
--- a/examples/timer_notify.rs
+++ b/examples/timer_notify.rs
@@ -4,8 +4,6 @@ fn main() -> Result<(), EspError> {
     // It is necessary to call this function once. Otherwise some patches to the runtime
     // implemented by esp-idf-sys might not link properly. See https://github.com/esp-rs/esp-idf-template/issues/71
     esp_idf_sys::link_patches();
-    // Bind the log crate to the ESP Logging facilities
-    esp_idf_svc::log::EspLogger::initialize_default();
 
     let per = esp_idf_hal::peripherals::Peripherals::take().unwrap();
 

--- a/examples/timer_notify.rs
+++ b/examples/timer_notify.rs
@@ -1,0 +1,56 @@
+use esp_idf_sys::{self as _, EspError, TaskHandle_t}; // If using the `binstart` feature of `esp-idf-sys`, always keep this module imported
+use log::*;
+
+fn main() -> Result<(), EspError> {
+    // It is necessary to call this function once. Otherwise some patches to the runtime
+    // implemented by esp-idf-sys might not link properly. See https://github.com/esp-rs/esp-idf-template/issues/71
+    esp_idf_sys::link_patches();
+    // Bind the log crate to the ESP Logging facilities
+    esp_idf_svc::log::EspLogger::initialize_default();
+
+    let per = esp_idf_hal::peripherals::Peripherals::take().unwrap();
+
+    // This handle will be used as the address for the event in the callback.
+    // Make sure that the handle / thread lives always longer as the callback it is used in
+    let main_task_handle: TaskHandle_t = esp_idf_hal::task::current().unwrap();
+
+    // BaseClock for the Timer is the APB_CLK that is running on 80MHz at default
+    // The default clock-divider is -> 80
+    // default APB clk is available with the APB_CLK_FREQ constant
+    let timer_conf = esp_idf_hal::timer::config::Config::new().auto_reload(true);
+    let mut timer = esp_idf_hal::timer::TimerDriver::new(per.timer00, &timer_conf)?;
+
+    // Calculate value needed for alarm in seconds
+    // (APB_CLK_FREQ / DEVIDER ) * seconds = count
+    // example every 200 us
+    // ( 80*10^6 / 80 ) * 200 *10^(-6) = 200
+    timer.set_alarm(200)?;
+
+    // Saftey: make sure the task handle stays valid for longer than the subscribtion
+    // is active
+    unsafe {
+        timer.subscribe(move || {
+            let event_number = 42;
+            esp_idf_hal::task::notify(main_task_handle, event_number);
+        })?;
+    }
+
+    timer.enable_alarm(true)?;
+    timer.enable(true)?;
+
+    loop {
+        // Notify approach
+        // The benefit with this approach over checking a global static variable is
+        // That the scheduler can hold the task, and resume when signaled
+        // so no spinlock is needed
+        let event_id = esp_idf_hal::task::wait_notification(None);
+
+        // Note that the println functions are to slow for 200us
+        // Even if we just send one charachter we can not go below 1ms per msg
+        // so we are missing some events here - but if they are evaluated without
+        // printing them the maintask will be fast enough no problem
+        if let Some(event) = event_id {
+            info!("got event with the number {event} from ISR");
+        }
+    }
+}

--- a/examples/timer_notify.rs
+++ b/examples/timer_notify.rs
@@ -1,5 +1,4 @@
 use esp_idf_sys::{self as _, EspError, TaskHandle_t}; // If using the `binstart` feature of `esp-idf-sys`, always keep this module imported
-use log::*;
 
 fn main() -> Result<(), EspError> {
     // It is necessary to call this function once. Otherwise some patches to the runtime
@@ -41,7 +40,7 @@ fn main() -> Result<(), EspError> {
     loop {
         // Notify approach
         // The benefit with this approach over checking a global static variable is
-        // That the scheduler can hold the task, and resume when signaled
+        // that the scheduler can hold the task, and resume when signaled
         // so no spinlock is needed
         let event_id = esp_idf_hal::task::wait_notification(None);
 
@@ -50,7 +49,7 @@ fn main() -> Result<(), EspError> {
         // so we are missing some events here - but if they are evaluated without
         // printing them the maintask will be fast enough no problem
         if let Some(event) = event_id {
-            info!("got event with the number {event} from ISR");
+            println!("got event with the number {event} from ISR");
         }
     }
 }


### PR DESCRIPTION
A simple example how to notify a task from a hardware timer ISR.
I think using the EspTimer is more useful, but people like to use the Hardware timer directly so that's why i made the example. 
CI will tell me if that's is working in newer IDF versions. Might need to rework the API for IDF 5 since they axed the api and now have it called general purpose timer.