### PR TITLE
Fix building for ESP32C2

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -13,7 +13,7 @@ use crate::peripheral::{Peripheral, PeripheralRef};
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub type AdcConfig = config::Config;
 
-#[cfg(all(not(feature = "riscv-ulp-hal"), not(esp_idf_version_major = "4")))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), not(esp_idf_version_major = "4"), not(esp32c2)))]
 pub use continuous::{
     config as cont_config, config::Config as AdcContConfig, AdcChannels, AdcChannelsArray,
     AdcDriver as AdcContDriver, AdcMeasurement, Atten11dB, Atten2p5dB, Atten6dB, AttenNone,
@@ -450,7 +450,7 @@ impl_adc!(ADC1: adc_unit_t_ADC_UNIT_1);
 #[cfg(not(any(esp32c2, esp32h2, esp32c5, esp32c6, esp32p4)))] // TODO: Check for esp32c5 and esp32p4
 impl_adc!(ADC2: adc_unit_t_ADC_UNIT_2);
 
-#[cfg(all(not(feature = "riscv-ulp-hal"), not(esp_idf_version_major = "4")))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), not(esp_idf_version_major = "4"), not(esp32c2)))]
 pub mod continuous {
     use core::ffi::c_void;
     use core::fmt::{self, Debug, Display};

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -13,7 +13,11 @@ use crate::peripheral::{Peripheral, PeripheralRef};
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub type AdcConfig = config::Config;
 
-#[cfg(all(not(feature = "riscv-ulp-hal"), not(esp_idf_version_major = "4"), not(esp32c2)))]
+#[cfg(all(
+    not(feature = "riscv-ulp-hal"),
+    not(esp_idf_version_major = "4"),
+    not(esp32c2)
+))]
 pub use continuous::{
     config as cont_config, config::Config as AdcContConfig, AdcChannels, AdcChannelsArray,
     AdcDriver as AdcContDriver, AdcMeasurement, Atten11dB, Atten2p5dB, Atten6dB, AttenNone,
@@ -450,7 +454,11 @@ impl_adc!(ADC1: adc_unit_t_ADC_UNIT_1);
 #[cfg(not(any(esp32c2, esp32h2, esp32c5, esp32c6, esp32p4)))] // TODO: Check for esp32c5 and esp32p4
 impl_adc!(ADC2: adc_unit_t_ADC_UNIT_2);
 
-#[cfg(all(not(feature = "riscv-ulp-hal"), not(esp_idf_version_major = "4"), not(esp32c2)))]
+#[cfg(all(
+    not(feature = "riscv-ulp-hal"),
+    not(esp_idf_version_major = "4"),
+    not(esp32c2)
+))]
 pub mod continuous {
     use core::ffi::c_void;
     use core::fmt::{self, Debug, Display};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ compile_error!("Feature `riscv-ulp-hal` is currently only supported on esp32s2")
 
 #[macro_use]
 pub mod riscv_ulp_hal;
-
+#[cfg(all(esp_idf_comp_esp_adc_enabled, esp_idf_soc_adc_supported))]
 pub mod adc;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub mod can;
@@ -43,7 +43,7 @@ pub mod gpio;
 pub mod hall;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub mod i2c;
-#[cfg(all(not(feature = "riscv-ulp-hal"), esp_idf_comp_driver_enabled))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), esp_idf_comp_driver_enabled, esp_idf_soc_i2s_supported))]
 pub mod i2s;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub mod interrupt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,11 @@ pub mod gpio;
 pub mod hall;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub mod i2c;
-#[cfg(all(not(feature = "riscv-ulp-hal"), esp_idf_comp_driver_enabled, esp_idf_soc_i2s_supported))]
+#[cfg(all(
+    not(feature = "riscv-ulp-hal"),
+    esp_idf_comp_driver_enabled,
+    esp_idf_soc_i2s_supported
+))]
 pub mod i2s;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub mod interrupt;

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -5,7 +5,11 @@ use crate::can;
 use crate::gpio;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 use crate::i2c;
-#[cfg(all(not(feature = "riscv-ulp-hal"), esp_idf_comp_driver_enabled, esp_idf_soc_i2s_supported))]
+#[cfg(all(
+    not(feature = "riscv-ulp-hal"),
+    esp_idf_comp_driver_enabled,
+    esp_idf_soc_i2s_supported
+))]
 use crate::i2s;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 use crate::ledc;
@@ -56,9 +60,18 @@ pub struct Peripherals {
     pub i2c0: i2c::I2C0,
     #[cfg(all(not(any(esp32c3, esp32c2, esp32c6)), not(feature = "riscv-ulp-hal")))]
     pub i2c1: i2c::I2C1,
-    #[cfg(all(not(feature = "riscv-ulp-hal"), esp_idf_comp_driver_enabled, esp_idf_soc_i2s_supported))]
+    #[cfg(all(
+        not(feature = "riscv-ulp-hal"),
+        esp_idf_comp_driver_enabled,
+        esp_idf_soc_i2s_supported
+    ))]
     pub i2s0: i2s::I2S0,
-    #[cfg(all(not(feature = "riscv-ulp-hal"), any(esp32, esp32s3), esp_idf_comp_driver_enabled, esp_idf_soc_i2s_supported))]
+    #[cfg(all(
+        not(feature = "riscv-ulp-hal"),
+        any(esp32, esp32s3),
+        esp_idf_comp_driver_enabled,
+        esp_idf_soc_i2s_supported
+    ))]
     pub i2s1: i2s::I2S1,
     #[cfg(not(feature = "riscv-ulp-hal"))]
     pub spi1: spi::SPI1,
@@ -68,7 +81,11 @@ pub struct Peripherals {
     pub spi3: spi::SPI3,
     #[cfg(all(esp_idf_comp_esp_adc_enabled, esp_idf_soc_adc_supported))]
     pub adc1: adc::ADC1,
-    #[cfg(all(esp_idf_comp_esp_adc_enabled, esp_idf_soc_adc_supported, any(esp32, esp32s2, esp32s3, esp32c3)))]
+    #[cfg(all(
+        esp_idf_comp_esp_adc_enabled,
+        esp_idf_soc_adc_supported,
+        any(esp32, esp32s2, esp32s3, esp32c3)
+    ))]
     pub adc2: adc::ADC2,
     // TODO: Check the pulse counter story for c2, h2, c5, c6, and p4
     #[cfg(all(not(feature = "riscv-ulp-hal"), any(esp32, esp32s2, esp32s3)))]
@@ -200,9 +217,18 @@ impl Peripherals {
             i2c0: i2c::I2C0::new(),
             #[cfg(all(not(any(esp32c3, esp32c2, esp32c6)), not(feature = "riscv-ulp-hal")))]
             i2c1: i2c::I2C1::new(),
-            #[cfg(all(not(feature = "riscv-ulp-hal"), esp_idf_comp_driver_enabled, esp_idf_soc_i2s_supported))]
+            #[cfg(all(
+                not(feature = "riscv-ulp-hal"),
+                esp_idf_comp_driver_enabled,
+                esp_idf_soc_i2s_supported
+            ))]
             i2s0: i2s::I2S0::new(),
-            #[cfg(all(not(feature = "riscv-ulp-hal"), any(esp32, esp32s3), esp_idf_comp_driver_enabled, esp_idf_soc_i2s_supported))]
+            #[cfg(all(
+                not(feature = "riscv-ulp-hal"),
+                any(esp32, esp32s3),
+                esp_idf_comp_driver_enabled,
+                esp_idf_soc_i2s_supported
+            ))]
             i2s1: i2s::I2S1::new(),
             #[cfg(not(feature = "riscv-ulp-hal"))]
             spi1: spi::SPI1::new(),
@@ -212,7 +238,11 @@ impl Peripherals {
             spi3: spi::SPI3::new(),
             #[cfg(all(esp_idf_comp_esp_adc_enabled, esp_idf_soc_adc_supported))]
             adc1: adc::ADC1::new(),
-            #[cfg(all(esp_idf_comp_esp_adc_enabled, esp_idf_soc_adc_supported, any(esp32, esp32s2, esp32s3, esp32c3)))]
+            #[cfg(all(
+                esp_idf_comp_esp_adc_enabled,
+                esp_idf_soc_adc_supported,
+                any(esp32, esp32s2, esp32s3, esp32c3)
+            ))]
             adc2: adc::ADC2::new(),
             #[cfg(all(not(feature = "riscv-ulp-hal"), any(esp32, esp32s2, esp32s3)))]
             pcnt0: pcnt::PCNT0::new(),

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -1,10 +1,11 @@
+#[cfg(all(esp_idf_comp_esp_adc_enabled, esp_idf_soc_adc_supported))]
 use crate::adc;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 use crate::can;
 use crate::gpio;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 use crate::i2c;
-#[cfg(not(feature = "riscv-ulp-hal"))]
+#[cfg(all(not(feature = "riscv-ulp-hal"), esp_idf_comp_driver_enabled, esp_idf_soc_i2s_supported))]
 use crate::i2s;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 use crate::ledc;
@@ -55,9 +56,9 @@ pub struct Peripherals {
     pub i2c0: i2c::I2C0,
     #[cfg(all(not(any(esp32c3, esp32c2, esp32c6)), not(feature = "riscv-ulp-hal")))]
     pub i2c1: i2c::I2C1,
-    #[cfg(not(feature = "riscv-ulp-hal"))]
+    #[cfg(all(not(feature = "riscv-ulp-hal"), esp_idf_comp_driver_enabled, esp_idf_soc_i2s_supported))]
     pub i2s0: i2s::I2S0,
-    #[cfg(all(any(esp32, esp32s3), not(feature = "riscv-ulp-hal")))]
+    #[cfg(all(not(feature = "riscv-ulp-hal"), any(esp32, esp32s3), esp_idf_comp_driver_enabled, esp_idf_soc_i2s_supported))]
     pub i2s1: i2s::I2S1,
     #[cfg(not(feature = "riscv-ulp-hal"))]
     pub spi1: spi::SPI1,
@@ -65,8 +66,9 @@ pub struct Peripherals {
     pub spi2: spi::SPI2,
     #[cfg(all(any(esp32, esp32s2, esp32s3), not(feature = "riscv-ulp-hal")))]
     pub spi3: spi::SPI3,
+    #[cfg(all(esp_idf_comp_esp_adc_enabled, esp_idf_soc_adc_supported))]
     pub adc1: adc::ADC1,
-    #[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
+    #[cfg(all(esp_idf_comp_esp_adc_enabled, esp_idf_soc_adc_supported, any(esp32, esp32s2, esp32s3, esp32c3)))]
     pub adc2: adc::ADC2,
     // TODO: Check the pulse counter story for c2, h2, c5, c6, and p4
     #[cfg(all(not(feature = "riscv-ulp-hal"), any(esp32, esp32s2, esp32s3)))]
@@ -198,9 +200,9 @@ impl Peripherals {
             i2c0: i2c::I2C0::new(),
             #[cfg(all(not(any(esp32c3, esp32c2, esp32c6)), not(feature = "riscv-ulp-hal")))]
             i2c1: i2c::I2C1::new(),
-            #[cfg(not(feature = "riscv-ulp-hal"))]
+            #[cfg(all(not(feature = "riscv-ulp-hal"), esp_idf_comp_driver_enabled, esp_idf_soc_i2s_supported))]
             i2s0: i2s::I2S0::new(),
-            #[cfg(all(any(esp32, esp32s3), not(feature = "riscv-ulp-hal")))]
+            #[cfg(all(not(feature = "riscv-ulp-hal"), any(esp32, esp32s3), esp_idf_comp_driver_enabled, esp_idf_soc_i2s_supported))]
             i2s1: i2s::I2S1::new(),
             #[cfg(not(feature = "riscv-ulp-hal"))]
             spi1: spi::SPI1::new(),
@@ -208,8 +210,9 @@ impl Peripherals {
             spi2: spi::SPI2::new(),
             #[cfg(all(any(esp32, esp32s2, esp32s3), not(feature = "riscv-ulp-hal")))]
             spi3: spi::SPI3::new(),
+            #[cfg(all(esp_idf_comp_esp_adc_enabled, esp_idf_soc_adc_supported))]
             adc1: adc::ADC1::new(),
-            #[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
+            #[cfg(all(esp_idf_comp_esp_adc_enabled, esp_idf_soc_adc_supported, any(esp32, esp32s2, esp32s3, esp32c3)))]
             adc2: adc::ADC2::new(),
             #[cfg(all(not(feature = "riscv-ulp-hal"), any(esp32, esp32s2, esp32s3)))]
             pcnt0: pcnt::PCNT0::new(),


### PR DESCRIPTION
This fixes building on ESP32C2.

Specifically:
* ADC continuous mode isn't supported.
* I2S isn't supported.

I2S is fixed by adding checks for the `esp_idf_soc_adc_supported` cfg attribute. There isn't a similar attribute for ADC continuous mode, unfortunately, so we have to check for `not(esp32c2)` instead.