### PR TITLE
Fix building for ESP32C2.

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -13,7 +13,11 @@ use crate::peripheral::{Peripheral, PeripheralRef};
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub type AdcConfig = config::Config;
 
-#[cfg(all(not(feature = "riscv-ulp-hal"), not(esp_idf_version_major = "4")))]
+#[cfg(all(
+    not(feature = "riscv-ulp-hal"),
+    not(esp_idf_version_major = "4"),
+    not(esp32c2)
+))]
 pub use continuous::{
     config as cont_config, config::Config as AdcContConfig, AdcChannels, AdcChannelsArray,
     AdcDriver as AdcContDriver, AdcMeasurement, Atten11dB, Atten2p5dB, Atten6dB, AttenNone,
@@ -773,7 +777,11 @@ pub mod oneshot {
     unsafe impl<'d, ADC: Adc> Sync for AdcDriver<'d, ADC> {}
 }
 
-#[cfg(all(not(feature = "riscv-ulp-hal"), not(esp_idf_version_major = "4")))]
+#[cfg(all(
+    not(feature = "riscv-ulp-hal"),
+    not(esp_idf_version_major = "4"),
+    not(esp32c2)
+))]
 pub mod continuous {
     use core::ffi::c_void;
     use core::fmt::{self, Debug, Display};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,10 @@ pub mod hall;
 pub mod i2c;
 #[cfg(all(
     not(feature = "riscv-ulp-hal"),
-    not(esp32c2),
+    esp_idf_soc_i2s_supported,
     esp_idf_comp_driver_enabled
 ))]
-#[cfg_attr(feature = "nightly", doc(cfg(not(esp32c2))))]
+#[cfg_attr(feature = "nightly", doc(cfg(esp_idf_soc_adc_supported)))]
 pub mod i2s;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 pub mod interrupt;

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -4,7 +4,11 @@ use crate::can;
 use crate::gpio;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 use crate::i2c;
-#[cfg(not(feature = "riscv-ulp-hal"))]
+#[cfg(all(
+    not(feature = "riscv-ulp-hal"),
+    esp_idf_soc_i2s_supported,
+    esp_idf_comp_driver_enabled
+))]
 use crate::i2s;
 #[cfg(not(feature = "riscv-ulp-hal"))]
 use crate::ledc;
@@ -55,9 +59,18 @@ pub struct Peripherals {
     pub i2c0: i2c::I2C0,
     #[cfg(all(not(any(esp32c3, esp32c2, esp32c6)), not(feature = "riscv-ulp-hal")))]
     pub i2c1: i2c::I2C1,
-    #[cfg(not(feature = "riscv-ulp-hal"))]
+    #[cfg(all(
+        not(feature = "riscv-ulp-hal"),
+        esp_idf_soc_i2s_supported,
+        esp_idf_comp_driver_enabled
+    ))]
     pub i2s0: i2s::I2S0,
-    #[cfg(all(any(esp32, esp32s3), not(feature = "riscv-ulp-hal")))]
+    #[cfg(all(
+        not(feature = "riscv-ulp-hal"),
+        esp_idf_soc_i2s_supported,
+        esp_idf_comp_driver_enabled,
+        any(esp32, esp32s3)
+    ))]
     pub i2s1: i2s::I2S1,
     #[cfg(not(feature = "riscv-ulp-hal"))]
     pub spi1: spi::SPI1,
@@ -198,9 +211,18 @@ impl Peripherals {
             i2c0: i2c::I2C0::new(),
             #[cfg(all(not(any(esp32c3, esp32c2, esp32c6)), not(feature = "riscv-ulp-hal")))]
             i2c1: i2c::I2C1::new(),
-            #[cfg(not(feature = "riscv-ulp-hal"))]
+            #[cfg(all(
+                not(feature = "riscv-ulp-hal"),
+                esp_idf_soc_i2s_supported,
+                esp_idf_comp_driver_enabled
+            ))]
             i2s0: i2s::I2S0::new(),
-            #[cfg(all(any(esp32, esp32s3), not(feature = "riscv-ulp-hal")))]
+            #[cfg(all(
+                not(feature = "riscv-ulp-hal"),
+                esp_idf_soc_i2s_supported,
+                esp_idf_comp_driver_enabled,
+                any(esp32, esp32s3)
+            ))]
             i2s1: i2s::I2S1::new(),
             #[cfg(not(feature = "riscv-ulp-hal"))]
             spi1: spi::SPI1::new(),


### PR DESCRIPTION
Fixes https://github.com/esp-rs/esp-idf-hal/issues/282.

ESP32C2 doesn't have an I2S peripheral. This is fixed by adding `esp_idf_soc_i2s_supported` cfg checks in various places.

ESP32C2's ADC perhiperhal doesn't have a continuous mode. Alas, ESP-IDF doesn't expose a flag for this, so we have to add a few `not(esp32c2)` checks in places.