### PR TITLE
Fix ambiguous name error

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -229,7 +229,7 @@ pub fn block_on<F>(mut fut: F) -> F::Output
 where
     F: Future,
 {
-    log::trace!("block_on(): started");
+    ::log::trace!("block_on(): started");
 
     let notification = notification::Notification::new();
 
@@ -246,7 +246,7 @@ where
         }
     };
 
-    log::trace!("block_on(): finished");
+    ::log::trace!("block_on(): finished");
 
     res
 }


### PR DESCRIPTION
I use NimBLE BLE stack.
In NimBLE library, a log structure is defined.  Therefore, `esp_idf_sys::log` is defined in esp_idf_sys.
(see: https://github.com/espressif/esp-nimble/blob/f8f02740acdf4d302d5c2f91ee2e34444d405671/porting/nimble/include/log/log.h#L39)

In task.rs, the log crate and sys_idf_sys::log are ambiguous and the following error occurs.
I changed to use the log crate explicitly.

```
error[E0659]: `log` is ambiguous
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-hal-0.42.0/src/task.rs:232:5
    |
232 |     log::trace!("block_on(): started");
    |     ^^^ ambiguous name
    |
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
    = note: `log` could refer to a crate passed with `--extern`
    = help: use `::log` to refer to this crate unambiguously
note: `log` could also refer to the struct imported here
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-hal-0.42.0/src/task.rs:15:5
    |
15  | use esp_idf_sys::*;
    |     ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `log` to disambiguate
    = help: or use `self::log` to refer to this struct unambiguously

error[E0659]: `log` is ambiguous
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-hal-0.42.0/src/task.rs:249:5
    |
249 |     log::trace!("block_on(): finished");
    |     ^^^ ambiguous name
    |
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
    = note: `log` could refer to a crate passed with `--extern`
    = help: use `::log` to refer to this crate unambiguously
note: `log` could also refer to the struct imported here
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-hal-0.42.0/src/task.rs:15:5
    |
15  | use esp_idf_sys::*;
    |     ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `log` to disambiguate
    = help: or use `self::log` to refer to this struct unambiguously
```