### PR TITLE
Fix gpio typo

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -2563,10 +2563,10 @@ mod chip {
         pub gpio19: Gpio19,
         pub gpio20: Gpio20,
         pub gpio21: Gpio21,
-        pub gpio22: Gpio21,
-        pub gpio23: Gpio21,
-        pub gpio24: Gpio21,
-        pub gpio25: Gpio21,
+        pub gpio22: Gpio22,
+        pub gpio23: Gpio23,
+        pub gpio24: Gpio24,
+        pub gpio25: Gpio25,
         #[cfg(not(feature = "riscv-ulp-hal"))]
         pub gpio26: Gpio26,
         #[cfg(not(feature = "riscv-ulp-hal"))]


### PR DESCRIPTION
When compiling for esp32c6, the following compile error occurs.
```
error[E0308]: mismatched types
    --> /home/runner/.cargo/git/checkouts/esp-idf-hal-69a5b467b1ae0b2e/279cc87/src/gpio.rs:2611:25
     |
2611 |                 gpio22: Gpio22::new(),
     |                         ^^^^^^^^^^^^^ expected `Gpio21`, found `Gpio22`

error[E0308]: mismatched types
    --> /home/runner/.cargo/git/checkouts/esp-idf-hal-69a5b467b1ae0b2e/279cc87/src/gpio.rs:2612:25
     |
2612 |                 gpio23: Gpio23::new(),
     |                         ^^^^^^^^^^^^^ expected `Gpio21`, found `Gpio23`

error[E0308]: mismatched types
    --> /home/runner/.cargo/git/checkouts/esp-idf-hal-69a5b467b1ae0b2e/279cc87/src/gpio.rs:2613:25
     |
2613 |                 gpio24: Gpio24::new(),
     |                         ^^^^^^^^^^^^^ expected `Gpio21`, found `Gpio24`

error[E0308]: mismatched types
    --> /home/runner/.cargo/git/checkouts/esp-idf-hal-69a5b467b1ae0b2e/279cc87/src/gpio.rs:2614:25
     |
2614 |                 gpio25: Gpio25::new(),
     |                         ^^^^^^^^^^^^^ expected `Gpio21`, found `Gpio25`
```