### PR TITLE
Update i2c_master_slave.rs

### DIFF
--- a/examples/i2c_master_slave.rs
+++ b/examples/i2c_master_slave.rs
@@ -67,7 +67,7 @@ fn main() -> anyhow::Result<()> {
     let mut i2c_master = i2c_master_init(
         peripherals.i2c0,
         peripherals.pins.gpio21.into(),
-        peripherals.pins.gpio22.into(),
+        peripherals.pins.gpio20.into(),
         100.kHz().into(),
     )?;
 

--- a/examples/i2c_master_slave.rs
+++ b/examples/i2c_master_slave.rs
@@ -2,7 +2,7 @@
 //!
 //! Wiring required, but can be changed in main():
 //! - GPIO21 to GPIO18
-//! - GPIO22 to GPIO19
+//! - GPIO20 to GPIO19
 //!
 //! ESP32-C2/C3 does not have two I2C peripherals, so this ecample will not work.
 //!


### PR DESCRIPTION
esp32s3 does not have GPIO22, using GPIO20 instead.
perhaps it is best to change the pins in the example, to suit any kind of esp32
https://github.com/esp-rs/esp-idf-hal/issues/329