### PR TITLE
🐛 fix wrong array indexing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.3] - 2023-10-29
+* Fix Timer array index bug #331 - prevented the use of TIMER10 on devices that support only 2 Timers
+* Fix wrong TIMER11 index definition that declared TIMER11 as TIMER10 #331
+
 ## [0.42.2] - 2023-10-28
 * Support for latest ESP IDF 5.2 dev (master)
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -427,4 +427,4 @@ impl_timer!(TIMER01: timer_group_t_TIMER_GROUP_0, timer_idx_t_TIMER_1);
 #[cfg(not(esp32c2))]
 impl_timer!(TIMER10: timer_group_t_TIMER_GROUP_1, timer_idx_t_TIMER_0);
 #[cfg(any(esp32, esp32s2, esp32s3))]
-impl_timer!(TIMER11: timer_group_t_TIMER_GROUP_1, timer_idx_t_TIMER_0);
+impl_timer!(TIMER11: timer_group_t_TIMER_GROUP_1, timer_idx_t_TIMER_1);

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -226,8 +226,7 @@ impl<'d> TimerDriver<'d> {
                     self.group(),
                     self.index(),
                     Some(Self::handle_isr),
-                    (self.group() + self.index() * timer_group_t_TIMER_GROUP_MAX)
-                        as *mut core::ffi::c_void,
+                    (self.group() + self.index() * timer_idx_t_TIMER_MAX) as *mut core::ffi::c_void,
                     0,
                 )
             })?;
@@ -267,14 +266,12 @@ impl<'d> TimerDriver<'d> {
     }
 
     pub fn reset_wait(&mut self) {
-        let notif =
-            &PIN_NOTIF[(self.group() + self.index() * timer_group_t_TIMER_GROUP_MAX) as usize];
+        let notif = &PIN_NOTIF[(self.group() + self.index() * timer_idx_t_TIMER_MAX) as usize];
         notif.reset();
     }
 
     pub async fn wait(&mut self) -> Result<(), EspError> {
-        let notif =
-            &PIN_NOTIF[(self.group() + self.index() * timer_group_t_TIMER_GROUP_MAX) as usize];
+        let notif = &PIN_NOTIF[(self.group() + self.index() * timer_idx_t_TIMER_MAX) as usize];
 
         notif.wait().await;
 
@@ -297,7 +294,7 @@ impl<'d> TimerDriver<'d> {
 
         let callback: Box<dyn FnMut() + Send + 'd> = Box::new(callback);
 
-        ISR_HANDLERS[(self.group() + self.index() * timer_group_t_TIMER_GROUP_MAX) as usize] =
+        ISR_HANDLERS[(self.group() + self.index() * timer_idx_t_TIMER_MAX) as usize] =
             Some(unsafe { core::mem::transmute(callback) });
 
         Ok(())
@@ -310,8 +307,7 @@ impl<'d> TimerDriver<'d> {
         self.disable_interrupt()?;
 
         unsafe {
-            ISR_HANDLERS[(self.group() + self.index() * timer_group_t_TIMER_GROUP_MAX) as usize] =
-                None;
+            ISR_HANDLERS[(self.group() + self.index() * timer_idx_t_TIMER_MAX) as usize] = None;
         }
 
         Ok(())
@@ -355,11 +351,10 @@ impl<'d> Drop for TimerDriver<'d> {
 
         #[cfg(feature = "alloc")]
         unsafe {
-            ISR_HANDLERS[(self.group() + self.index() * timer_group_t_TIMER_GROUP_MAX) as usize] =
-                None;
+            ISR_HANDLERS[(self.group() + self.index() * timer_idx_t_TIMER_MAX) as usize] = None;
         }
 
-        PIN_NOTIF[(self.group() + self.index() * timer_group_t_TIMER_GROUP_MAX) as usize].reset();
+        PIN_NOTIF[(self.group() + self.index() * timer_idx_t_TIMER_MAX) as usize].reset();
 
         esp!(unsafe { timer_deinit(self.group(), self.index()) }).unwrap();
     }


### PR DESCRIPTION
On all devices that only use 2Timers / 1 group the current logic will wrongly index into the the 
`static mut ISR_HANDLERS: [Option<Box<dyn FnMut() + Send + 'static>>; 2] = [None, None];` array.

The old calculation produces 2 for group 1 index 0 .... 