### PR TITLE
Impl Peripheral for I2s trait

### DIFF
--- a/src/i2s.rs
+++ b/src/i2s.rs
@@ -22,7 +22,7 @@ use esp_idf_sys::{
 
 #[cfg(not(esp_idf_version_major = "4"))]
 use crate::interrupt::asynch::HalIsrNotification;
-use crate::{delay, io::EspIOError};
+use crate::{delay, io::EspIOError, peripheral::Peripheral};
 
 // For v5+, we rely configuration options for PDM/TDM support.
 // For v4, we have to examine the chip type.
@@ -481,7 +481,7 @@ pub mod config {
 }
 
 /// Trait implemented by I2S peripherals to obtain their port number.
-pub trait I2s: Send + sealed::Sealed {
+pub trait I2s: Peripheral<P = Self> + Send + sealed::Sealed {
     /// Return the port number for the peripheral.
     fn port() -> i2s_port_t;
 }


### PR DESCRIPTION
This PR changes the [I2s](https://github.com/esp-rs/esp-idf-hal/blob/f917d5302b11b938e23280808afa9c2548be75fc/src/i2s.rs#L484) trait so that it is a superset of the [Peripheral](https://github.com/esp-rs/esp-idf-hal/blob/f917d5302b11b938e23280808afa9c2548be75fc/src/peripheral.rs#L134C17-L134C17) trait.

I recently got into a situation where I was trying to pass a `PeripheralRef<'_, I2s>` into `I2sDriver::new_std_tx` and found it problematic because the `I2s` trait does not necessarily guarantee it is a `Peripheral`, rather `I2S0` and `I2S1` structs implement `Peripheral`, making it hard to go about generic implementations.

This change will make it a little bit easier to work with the API when dealing with generics.