### PR TITLE
Allow Pull Without Output Requirement

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1096,7 +1096,7 @@ impl<'d, T: Pin, MODE> PinDriver<'d, T, MODE> {
 
     pub fn set_pull(&mut self, pull: Pull) -> Result<(), EspError>
     where
-        T: InputPin,
+        T: Pin,
         MODE: InputMode,
     {
         if MODE::RTC {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1096,7 +1096,7 @@ impl<'d, T: Pin, MODE> PinDriver<'d, T, MODE> {
 
     pub fn set_pull(&mut self, pull: Pull) -> Result<(), EspError>
     where
-        T: InputPin + OutputPin,
+        T: InputPin,
         MODE: InputMode,
     {
         if MODE::RTC {


### PR DESCRIPTION
Being able to pull up or down doesn't necessarily require being able to output. This change allows better migration from other hal projects such as esp-hal where this kind of requirement is similar. While this does relax the gate on what kinds of pins can pull, it allows developers to write stricter functions when passing pins around. 