### PR TITLE
support uart that defaults to PLL_F80M

### DIFF
--- a/src/uart.rs
+++ b/src/uart.rs
@@ -216,6 +216,9 @@ pub mod config {
         /// UART source clock from `XTAL`
         #[cfg(esp_idf_soc_uart_support_xtal_clk)]
         Crystal,
+        /// UART source clock from `XTAL`
+        #[cfg(esp_idf_soc_uart_support_pll_f80m_clk)]
+        PLL_F80M,
         /// UART source clock from `REF_TICK`
         #[cfg(esp_idf_soc_uart_support_ref_tick)]
         RefTick,
@@ -242,6 +245,8 @@ pub mod config {
                 RTC_SCLK => SourceClock::RTC,
                 #[cfg(esp_idf_soc_uart_support_xtal_clk)]
                 XTAL_SCLK => SourceClock::Crystal,
+                #[cfg(esp_idf_soc_uart_support_pll_f80m_clk)]
+                PLL_F80M => SourceClock::PLL_F80M,
                 #[cfg(esp_idf_soc_uart_support_ref_tick)]
                 REF_TICK_SCLK => SourceClock::RefTick,
                 _ => unreachable!(),
@@ -279,6 +284,11 @@ pub mod config {
     #[cfg(all(esp_idf_version_major = "4", esp_idf_soc_uart_support_xtal_clk))]
     const XTAL_SCLK: uart_sclk_t = uart_sclk_t_UART_SCLK_XTAL;
 
+    #[cfg(all(not(esp_idf_version_major = "4"), esp_idf_soc_uart_support_pll_f80m_clk))]
+    const PLL_F80M_SCLK: uart_sclk_t = soc_periph_uart_clk_src_legacy_t_UART_SCLK_PLL_F80M;
+    #[cfg(all(esp_idf_version_major = "4", esp_idf_soc_uart_support_pll_f80m_clk))]
+    const PLL_F80M_SCLK: uart_sclk_t = uart_sclk_t_UART_SCLK_PLL_F80M;
+
     #[cfg(all(not(esp_idf_version_major = "4"), esp_idf_soc_uart_support_ref_tick))]
     const REF_TICK_SCLK: uart_sclk_t = soc_periph_uart_clk_src_legacy_t_UART_SCLK_REF_TICK;
     #[cfg(all(esp_idf_version_major = "4", esp_idf_soc_uart_support_ref_tick))]
@@ -303,6 +313,8 @@ pub mod config {
                 SourceClock::RTC => RTC_SCLK,
                 #[cfg(esp_idf_soc_uart_support_xtal_clk)]
                 SourceClock::Crystal => XTAL_SCLK,
+                #[cfg(esp_idf_soc_uart_support_pll_f80m_clk)]
+                SourceClock::PLL_F80M => PLL_F80M_SCLK,
                 #[cfg(esp_idf_soc_uart_support_ref_tick)]
                 SourceClock::RefTick => REF_TICK_SCLK,
             }


### PR DESCRIPTION
On an esp32c6 with idf 5.1.1 (devkitC, although I doubt that matters), I could not for the life of me get the uart example to work.  Eventually I figured out that, at least in my particular setup, the default clock for the UART is the PLL_F80M clock... which must not have existed in earlier IDFs (or maybe it's particular to the esp32c6? Not sure, but it doesn't really matter).

This PR simply adds support in for the UART_SCLK_PLL_F80M clock source, since without this I couldn't get past a panic from creating the default uart config.