### PR TITLE
fix: compile with esp_idf_adc_continuous_isr_iram_safe

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1323,6 +1323,7 @@ pub mod continuous {
 
             esp!(unsafe { adc_continuous_deinit(self.handle) }).unwrap();
 
+            #[cfg(not(esp_idf_adc_continuous_isr_iram_safe))]
             NOTIFIER[self.adc as usize].reset();
         }
     }


### PR DESCRIPTION
NOTIFIER is not defined with esp_idf_adc_continuous_isr_iram_safe