### PR TITLE
Update enumset to 1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ esp-idf-sys = { version = "0.33.7", default-features = false }
 critical-section = { version = "1.1.1", optional = true }
 heapless = "0.8"
 num_enum = { version = "0.7", default-features = false }
-enumset = { version = "1", default-features = false }
+enumset = { version = "1.1", default-features = false }
 log = { version = "0.4", default-features = false }
 atomic-waker = { version = "1.1.1", default-features = false }
 embassy-sync = { version = "0.5" }


### PR DESCRIPTION
Version change: "1" -> "1.1"
`src/uart.rs` uses `EnumSet::EMPTY` for a `const fn`. `EnumSet::EMPTY` is not available in 1.0.0, but first introduced in 1.1.