### PR TITLE
Add GPIO20 for esp32-pico-mini-02

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1647,6 +1647,7 @@ mod chip {
     pin!(Gpio17:17, IO, NORTC:0, NOADC:0, NODAC:0, NOTOUCH:0);
     pin!(Gpio18:18, IO, NORTC:0, NOADC:0, NODAC:0, NOTOUCH:0);
     pin!(Gpio19:19, IO, NORTC:0, NOADC:0, NODAC:0, NOTOUCH:0);
+    pin!(Gpio20:20, IO, NORTC:0, NOADC:0, NODAC:0, NOTOUCH:0);
     pin!(Gpio21:21, IO, NORTC:0, NOADC:0, NODAC:0, NOTOUCH:0);
     pin!(Gpio22:22, IO, NORTC:0, NOADC:0, NODAC:0, NOTOUCH:0);
     pin!(Gpio23:23, IO, NORTC:0, NOADC:0, NODAC:0, NOTOUCH:0);
@@ -1683,6 +1684,7 @@ mod chip {
         pub gpio17: Gpio17,
         pub gpio18: Gpio18,
         pub gpio19: Gpio19,
+        pub gpio20: Gpio20,
         pub gpio21: Gpio21,
         pub gpio22: Gpio22,
         pub gpio23: Gpio23,
@@ -1726,6 +1728,7 @@ mod chip {
                 gpio17: Gpio17::new(),
                 gpio18: Gpio18::new(),
                 gpio19: Gpio19::new(),
+                gpio20: Gpio20::new(),
                 gpio21: Gpio21::new(),
                 gpio22: Gpio22::new(),
                 gpio23: Gpio23::new(),


### PR DESCRIPTION
Adds gpio20 pin to esp32 target for using i2c on esp32-pico-mini-02 (such as in Adafruit ESP32 Feather V2). Fixes an issue referenced in https://github.com/esp-rs/esp-idf-hal/issues/108