### PR TITLE
Use `restore-state-none` feature in optional dependency `critical-section`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ embedded-hal-async = "1"
 embedded-io = "0.6"
 embedded-io-async = "0.6"
 esp-idf-sys = { version = "0.33.7", default-features = false }
-critical-section = { version = "1.1.1", optional = true }
+critical-section = { version = "1.1.1", optional = true, features = ["restore-state-none"] }
 heapless = "0.8"
 num_enum = { version = "0.7", default-features = false }
 enumset = { version = "1.1", default-features = false }


### PR DESCRIPTION
This should provide a slightly user-friendlier error message in the case that a user enables a different `restore-state` in `critical-section`.

Right now it's possible to e.g. enable the `std` feature on `critical-section`; `cargo` will not complain but `rustc` will complain about the return types of the `CriticalSection::enter` implementation.