### PR TITLE
Improve delay/timer errors and rounding calculations

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -23,7 +23,7 @@ impl TickType {
         Self(ticks)
     }
 
-    fn new_millis(ms: u64) -> Self {
+    pub fn new_millis(ms: u64) -> Self {
         let ticks = ms
             .saturating_mul(TICK_RATE_HZ as u64)
             .saturating_add(MS_PER_S - 1)

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -16,6 +16,8 @@ pub const TICK_RATE_HZ: u32 = configTICK_RATE_HZ;
 
 const MS_PER_S: u64 = 1_000;
 const NS_PER_MS: u64 = 1_000_000;
+const US_PER_MS: u32 = 1_000;
+const NS_PER_US: u32 = 1_000;
 
 #[repr(transparent)]
 pub struct TickType(pub TickType_t);
@@ -120,7 +122,7 @@ impl Ets {
     }
 
     pub fn delay_ms(ms: u32) {
-        Self::delay_us(ms.saturating_mul(1000));
+        Self::delay_us(ms.saturating_mul(US_PER_MS));
     }
 }
 
@@ -162,7 +164,7 @@ impl embedded_hal_0_2::blocking::delay::DelayMs<u8> for Ets {
 
 impl embedded_hal::delay::DelayNs for Ets {
     fn delay_ns(&mut self, ns: u32) {
-        Ets::delay_us(ns.saturating_add(999) / 1000)
+        Ets::delay_us(ns.saturating_add(NS_PER_US - 1) / NS_PER_US)
     }
 
     fn delay_us(&mut self, us: u32) {
@@ -189,7 +191,7 @@ impl FreeRtos {
     // This is not supposed to be `pub`, because the user code shall not use this
     // timer for microsecond delay. Only used for trait impl below.
     fn delay_us(us: u32) {
-        Self::delay_ms(us.saturating_add(999) / 1000);
+        Self::delay_ms(us.saturating_add(US_PER_MS - 1) / US_PER_MS);
     }
 }
 
@@ -231,7 +233,7 @@ impl embedded_hal_0_2::blocking::delay::DelayMs<u8> for FreeRtos {
 
 impl embedded_hal::delay::DelayNs for FreeRtos {
     fn delay_ns(&mut self, ns: u32) {
-        FreeRtos::delay_us(ns.saturating_add(999) / 1000);
+        FreeRtos::delay_us(ns.saturating_add(NS_PER_US - 1) / NS_PER_US);
     }
 
     fn delay_us(&mut self, us: u32) {
@@ -268,7 +270,7 @@ impl Delay {
     }
 
     pub fn delay_ms(&self, ms: u32) {
-        if ms.saturating_mul(1000) < self.0 {
+        if ms.saturating_mul(US_PER_MS) < self.0 {
             Ets::delay_ms(ms);
         } else {
             FreeRtos::delay_ms(ms);
@@ -278,7 +280,7 @@ impl Delay {
 
 impl embedded_hal::delay::DelayNs for Delay {
     fn delay_ns(&mut self, ns: u32) {
-        Delay::delay_us(self, ns.saturating_add(999) / 1000)
+        Delay::delay_us(self, ns.saturating_add(NS_PER_US - 1) / NS_PER_US)
     }
 
     fn delay_us(&mut self, us: u32) {

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -164,11 +164,15 @@ impl embedded_hal_0_2::blocking::delay::DelayMs<u8> for Ets {
 
 impl embedded_hal::delay::DelayNs for Ets {
     fn delay_ns(&mut self, ns: u32) {
-        Ets::delay_us(ns.saturating_add(NS_PER_US - 1) / NS_PER_US)
+        Ets::delay_us(ns.saturating_add(NS_PER_US - 1) / NS_PER_US);
     }
 
     fn delay_us(&mut self, us: u32) {
-        Ets::delay_us(us)
+        Ets::delay_us(us);
+    }
+
+    fn delay_ms(&mut self, ms: u32) {
+        Ets::delay_ms(ms);
     }
 }
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -12,7 +12,7 @@ pub use esp_idf_sys::TickType_t;
 
 pub const BLOCK: TickType_t = TickType_t::MAX;
 pub const NON_BLOCK: TickType_t = 0;
-pub const TICK_PERIOD_MS: u32 = 1000 / configTICK_RATE_HZ;
+pub const TICK_RATE_HZ: u32 = configTICK_RATE_HZ;
 const MS_PER_S: u64 = 1000;
 
 #[repr(transparent)]
@@ -25,7 +25,7 @@ impl TickType {
 
     fn new_millis(ms: u64) -> Self {
         let ticks = ms
-            .saturating_mul(configTICK_RATE_HZ as u64)
+            .saturating_mul(TICK_RATE_HZ as u64)
             .saturating_add(MS_PER_S - 1)
             / MS_PER_S;
         Self(min(ticks, TickType_t::MAX as _) as _)
@@ -38,8 +38,8 @@ impl TickType {
     pub fn as_millis(&self) -> u64 {
         (self.0 as u64)
             .saturating_mul(MS_PER_S)
-            .saturating_add(configTICK_RATE_HZ as u64 - 1)
-            / configTICK_RATE_HZ as u64
+            .saturating_add(TICK_RATE_HZ as u64 - 1)
+            / TICK_RATE_HZ as u64
     }
 
     pub fn as_millis_u32(&self) -> u32 {

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -10,13 +10,8 @@ use esp_idf_sys::*;
 
 pub use esp_idf_sys::TickType_t;
 
-#[allow(non_upper_case_globals)]
 pub const BLOCK: TickType_t = TickType_t::MAX;
-
-#[allow(non_upper_case_globals)]
 pub const NON_BLOCK: TickType_t = 0;
-
-#[allow(non_upper_case_globals)]
 pub const TICK_PERIOD_MS: u32 = 1000 / configTICK_RATE_HZ;
 
 #[repr(transparent)]


### PR DESCRIPTION
This change adjusts some time conversions to include less error and also round up for delay.

As discussed in #367 it's typically desired to round delay times up instead of down, because a delay usually waits for a thing (e.g. hardware) to finish. If we would round down, it is more likely to cause ill effects than rounding up. The user code usually expects delaying a bit more.
    
In case of the coarse timer the "waiting a bit more" may be fairly large. But if the user code uses a coarse timer for small delays it's a problem in the user code.
    
This change also converts a couple of 'as' conversions to 'into()' calls.

RFC1: What you you think about removing the constant TICK_PERIOD_MS? It's not used internally anymore, because it might include an error that will get large in multiplications. Shall we remove it from the public interface? If we remove it, we should probably export the timer rate in Hz.

RFC2: Shall we make TickType::new_millis() pub?

Thanks for you comments :)