### PR TITLE
feat(reset): Added restart return type

### DIFF
--- a/src/reset.rs
+++ b/src/reset.rs
@@ -97,8 +97,8 @@ impl WakeupReason {
     }
 }
 
-pub fn restart() {
+pub fn restart() -> ! {
     unsafe {
-        esp_restart();
+        esp_restart()
     }
 }

--- a/src/reset.rs
+++ b/src/reset.rs
@@ -98,7 +98,5 @@ impl WakeupReason {
 }
 
 pub fn restart() -> ! {
-    unsafe {
-        esp_restart()
-    }
+    unsafe { esp_restart() }
 }


### PR DESCRIPTION
Related issue: #382 

Explicitly set the return type of `reset::restart` as the [never type](https://doc.rust-lang.org/std/primitive.never.html).
This is already correctly set on the generated ffi bindings:

```rust
extern "C" {
    #[doc = " @brief  Restart PRO and APP CPUs.\n\n This function can be called both from PRO and APP CPUs.\n After successful restart, CPU reset reason will be SW_CPU_RESET.\n Peripherals (except for WiFi, BT, UART0, SPI1, and legacy timers) are not reset.\n This function does not return."]
    pub fn esp_restart() -> !;
}
```