### PR TITLE
add config_with_pin method to LedcDriver

### DIFF
--- a/src/ledc.rs
+++ b/src/ledc.rs
@@ -239,7 +239,7 @@ impl<'d> LedcDriver<'d> {
         Ok(driver)
     }
 
-    pub fn apply_config(&mut self) -> Result<(), EspError> {
+    fn apply_config(&mut self) -> Result<(), EspError> {
         let channel_config = ledc_channel_config_t {
             speed_mode: self.speed_mode.into(),
             channel: self.channel as u32,


### PR DESCRIPTION
In my project I need to drive more pins than there are ledc channels, but not at the same time

This pull request creates a way to change gpio pin on an already instantiated `LedcDriver` instance, so the channel needs only to be borrowed once

For context, the user then has to reconfigure the "orphan" gpio manually, so this is still an unsafe operation, but I guess this is outside the scope of the ledc driver, for now


let me know what you think

