### PR TITLE
Fix FixedLengthSignal::set

### DIFF
--- a/src/rmt.rs
+++ b/src/rmt.rs
@@ -868,7 +868,9 @@ impl<const N: usize> FixedLengthSignal<N> {
             .get_mut(index)
             .ok_or_else(|| EspError::from(ERR_ERANGE).unwrap())?;
 
-        Symbol(*item).update(pair.0, pair.1);
+        let mut symbol = Symbol(*item);
+        symbol.update(pair.0, pair.1);
+        *item = symbol.0;
         Ok(())
     }
 }


### PR DESCRIPTION
https://github.com/esp-rs/esp-idf-hal/commit/5657073293b8995c11cdaf175c82d54d14dc8050 has broken the RMT driver. `Symbol(*item)` creates a copy that is never assigned to anything, making the effects of `update` useless.

Fixes #389 