### PR TITLE
Add a feature gate for critical section impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ alloc = []
 nightly = []
 wake-from-isr = [] # Only enable if you plan to use the `edge-executor` crate
 embassy-sync = [] # For now, the dependecy on the `embassy-sync` crate is non-optional, but this might change in future
+critical-section = ["critical-section"]
+critical-section-isr = ["critical-section"]
+
 
 # Propagated esp-idf-sys features
 native = ["esp-idf-sys/native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ wake-from-isr = [] # Only enable if you plan to use the `edge-executor` crate
 embassy-sync = [
 ] # For now, the dependecy on the `embassy-sync` crate is non-optional, but this might change in future
 critical-section = ["critical-section/restore-state-none"]
-critical-section-isr = ["critical-section/restore-state-non"]
+critical-section-isr = ["critical-section/restore-state-none"]
 
 
 # Propagated esp-idf-sys features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ std = ["alloc", "esp-idf-sys/std"]
 alloc = []
 nightly = []
 wake-from-isr = [] # Only enable if you plan to use the `edge-executor` crate
-embassy-sync = [] # For now, the dependecy on the `embassy-sync` crate is non-optional, but this might change in future
-critical-section = ["critical-section"]
-critical-section-isr = ["critical-section"]
+embassy-sync = [
+] # For now, the dependecy on the `embassy-sync` crate is non-optional, but this might change in future
+critical-section = ["critical-section/restore-state-none"]
+critical-section-isr = ["critical-section/restore-state-non"]
 
 
 # Propagated esp-idf-sys features
@@ -38,13 +39,17 @@ libstart = ["esp-idf-sys/libstart"]
 nb = "1"
 embedded-can = "0.4.1"
 embedded-hal = "1"
-embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"] }
+embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.7", features = [
+    "unproven",
+] }
 embedded-hal-nb = "1"
 embedded-hal-async = "1"
 embedded-io = "0.6"
 embedded-io-async = "0.6"
 esp-idf-sys = { version = "0.34", default-features = false }
-critical-section = { version = "1.1.1", optional = true, features = ["restore-state-none"] }
+critical-section = { version = "1.1.1", optional = true, features = [
+    "restore-state-none",
+] }
 heapless = "0.8"
 num_enum = { version = "0.7", default-features = false }
 enumset = { version = "1.1", default-features = false }

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -663,6 +663,28 @@ pub mod asynch {
     }
 }
 
+#[cfg(feature = "critical-section-isr")]
+pub mod critical_section {
+
+    static CS_GUARD: std::sync::Mutex<Option<IsrCriticalSectionGuard>> = Mutex::new(None);
+
+    pub struct EspCriticalSection {}
+
+    unsafe impl critical_section::Impl for EspCriticalSection {
+        unsafe fn acquire() {
+            let mut guard = CS_GUARD.lock().unwrap();
+            *guard = Some(super::CS.enter());
+        }
+
+        unsafe fn release(_token: ()) {
+            let mut guard = CS_GUARD.lock().unwrap();
+            *guard = None;
+        }
+    }
+
+    critical_section::set_impl!(EspCriticalSection);
+}
+
 #[cfg(feature = "embassy-sync")]
 pub mod embassy_sync {
     use core::marker::PhantomData;

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -663,22 +663,23 @@ pub mod asynch {
     }
 }
 
+#[cfg(all(feature = "critical-section", feature = "critical-section-isr"))]
+compile_error!(
+    "Cannot enable both `critical-section` and `critical-section-isr` features at the same time."
+);
+
 #[cfg(feature = "critical-section-isr")]
 pub mod critical_section {
-
-    static CS_GUARD: std::sync::Mutex<Option<IsrCriticalSectionGuard>> = Mutex::new(None);
 
     pub struct EspCriticalSection {}
 
     unsafe impl critical_section::Impl for EspCriticalSection {
         unsafe fn acquire() {
-            let mut guard = CS_GUARD.lock().unwrap();
-            *guard = Some(super::CS.enter());
+            super::enter(&super::CS);
         }
 
         unsafe fn release(_token: ()) {
-            let mut guard = CS_GUARD.lock().unwrap();
-            *guard = None;
+            super::exit(&super::CS);
         }
     }
 


### PR DESCRIPTION
Adds a feature to enable the critical section implementation in `task.rs`, but also provides an alternative in `interrupt.rs` that  provides a critical section implementation that uses `IsrCriticalSection`, which prevents any interrupt
from happening while the critical section is acquired.

Here is an example of it's usage: https://github.com/beeb/coffee-scale-app/blob/main/rs/src/critical_section.rs (thanks beeb).