### PR TITLE
Enable pcnt for esp32c6

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub mod ledc;
 #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
 pub mod mac;
 pub mod modem;
-#[cfg(any(esp32, esp32s2, esp32s3))]
+#[cfg(any(esp32, esp32s2, esp32s3, esp32c6))]
 pub mod pcnt;
 pub mod peripheral;
 pub mod peripherals;

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -8,7 +8,7 @@ use crate::ledc;
 #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
 use crate::mac;
 use crate::modem;
-#[cfg(any(esp32, esp32s2, esp32s3))]
+#[cfg(any(esp32, esp32s2, esp32s3, esp32c6))]
 use crate::pcnt;
 use crate::rmt;
 use crate::spi;
@@ -144,13 +144,13 @@ impl Peripherals {
             adc1: adc::ADC1::new(),
             #[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
             adc2: adc::ADC2::new(),
-            #[cfg(any(esp32, esp32s2, esp32s3))]
+            #[cfg(any(esp32, esp32s2, esp32s3, esp32c6))]
             pcnt0: pcnt::PCNT0::new(),
-            #[cfg(any(esp32, esp32s2, esp32s3))]
+            #[cfg(any(esp32, esp32s2, esp32s3, esp32c6))]
             pcnt1: pcnt::PCNT1::new(),
-            #[cfg(any(esp32, esp32s2, esp32s3))]
+            #[cfg(any(esp32, esp32s2, esp32s3, esp32c6))]
             pcnt2: pcnt::PCNT2::new(),
-            #[cfg(any(esp32, esp32s2, esp32s3))]
+            #[cfg(any(esp32, esp32s2, esp32s3, esp32c6))]
             pcnt3: pcnt::PCNT3::new(),
             #[cfg(esp32)]
             pcnt4: pcnt::PCNT4::new(),

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -48,14 +48,14 @@ pub struct Peripherals {
     pub adc1: adc::ADC1,
     #[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
     pub adc2: adc::ADC2,
-    // TODO: Check the pulse counter story for c2, h2, c5, c6, and p4
-    #[cfg(any(esp32, esp32s2, esp32s3))]
+    // TODO: Check the pulse counter story for c2, h2, c5, and p4
+    #[cfg(any(esp32, esp32s2, esp32s3, esp32c6))]
     pub pcnt0: pcnt::PCNT0,
-    #[cfg(any(esp32, esp32s2, esp32s3))]
+    #[cfg(any(esp32, esp32s2, esp32s3, esp32c6))]
     pub pcnt1: pcnt::PCNT1,
-    #[cfg(any(esp32, esp32s2, esp32s3))]
+    #[cfg(any(esp32, esp32s2, esp32s3, esp32c6))]
     pub pcnt2: pcnt::PCNT2,
-    #[cfg(any(esp32, esp32s2, esp32s3))]
+    #[cfg(any(esp32, esp32s2, esp32s3, esp32c6))]
     pub pcnt3: pcnt::PCNT3,
     #[cfg(esp32)]
     pub pcnt4: pcnt::PCNT4,


### PR DESCRIPTION
The esp32c6 does have a pcnt unit according to the documentation that seems to be used via the same idf interface as the ones for esp32 cores. Enable it for the c6 as well. 
https://docs.espressif.com/projects/esp-idf/en/stable/esp32c6/api-reference/peripherals/pcnt.html