### PR TITLE
Added DelayUs and DelayMs U8 impls for Delay

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -411,6 +411,13 @@ impl embedded_hal::delay::DelayNs for Delay {
     }
 }
 
+impl embedded_hal_0_2::blocking::delay::DelayUs<u8> for Delay {
+    #[inline]
+    fn delay_us(&mut self, us: u8) {
+        Delay::delay_us(self, us.into());
+    }
+}
+
 impl embedded_hal_0_2::blocking::delay::DelayUs<u16> for Delay {
     #[inline]
     fn delay_us(&mut self, us: u16) {
@@ -422,6 +429,13 @@ impl embedded_hal_0_2::blocking::delay::DelayUs<u32> for Delay {
     #[inline]
     fn delay_us(&mut self, us: u32) {
         Delay::delay_us(self, us);
+    }
+}
+
+impl embedded_hal_0_2::blocking::delay::DelayMs<u8> for Delay {
+    #[inline]
+    fn delay_ms(&mut self, ms: u8) {
+        Delay::delay_ms(self, ms.into())
     }
 }
 


### PR DESCRIPTION
# What does it do?

Ive added impls for `embedded_hal_0_2::blocking::delay::DelayMs<u8>` and `embedded_hal_0_2::blocking::delay::DelayUs<u8>` for `esp-idf-hal`'s `Delay` type since `u16` and `u32` specializations were already present, but no `u8` version.

# Why is this important?

I've noticed that some crates using `embedded_hal` version `0.2.x`, like `epd-waveshare` require the `u8` specializations of `DelayMs` or `DelayUs`, for example [here](https://docs.rs/epd-waveshare/0.5.0/src/epd_waveshare/epd7in5/mod.rs.html#99-229). Since `Ets` had the specialzation already, I added them to `Delay` as well for convenience.
