### PR TITLE
Fix wrong max_duty for ledc

### DIFF
--- a/src/ledc.rs
+++ b/src/ledc.rs
@@ -470,7 +470,12 @@ mod chip {
         }
 
         pub const fn max_duty(&self) -> u32 {
-            (1 << self.bits()) - 1
+            // when using the maximum resultion, the duty cycle must not exceed 2^N - 1 to avoid timer overflow
+            if cfg!(esp32) && self.bits() == 20 || cfg!(not(esp32)) && self.bits() == 14 {
+                (1 << self.bits()) - 1
+            } else {
+                1 << self.bits()
+            }
         }
 
         pub(crate) const fn timer_bits(&self) -> ledc_timer_bit_t {


### PR DESCRIPTION
The max_duty cycle is wrong, the [ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/ledc.html#change-pwm-duty-cycle-using-software) states that the duty cycle is inclusive. It is only exclusive for the maximum timer resolution. I don't have fancy electronics, but a simple test with 1 bit resolution and an LED revealed a duty cycle of 1 only led to half brightness, while a value of 2 was full brightness.