### PR TITLE
Update embassy-sync version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ num_enum = { version = "0.7", default-features = false }
 enumset = { version = "1.1", default-features = false }
 log = { version = "0.4", default-features = false }
 atomic-waker = { version = "1.1.1", default-features = false }
-embassy-sync = { version = "0.5" }
+embassy-sync = { version = "0.6" }
 
 [build-dependencies]
 embuild = "0.31.3"


### PR DESCRIPTION
A new version of embassy-sync has been released that supports zero initialization. I think this is a pretty important change to update