### PR TITLE
Adding new_without_sclk SpiDriver constructor in SPI driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * adc: legacy adc driver is now behind a feature flag `adc-oneshot-legacy` starting with >= ESP-IDF v5.0. For justification, look at https://github.com/espressif/esp-idf/issues/13938. (#433)
 * spi: cs_pre/post_trans_delay() config option included. (#266)
 ### Added
+* spi: added new_without_sclk SpiDriver constructor (#440)
 * rmt: `Symbol` now derives `Clone` and `Copy` (#386)
 * reset: restart() function (#383)
 * pcnt: Can now be used with esp32c6. (#407)

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -49,7 +49,9 @@ use esp_idf_sys::*;
 use heapless::Deque;
 
 use crate::delay::{self, Ets, BLOCK};
-use crate::gpio::{AnyIOPin, AnyOutputPin, InputPin, Level, Output, OutputMode, OutputPin, PinDriver};
+use crate::gpio::{
+    AnyIOPin, AnyOutputPin, InputPin, Level, Output, OutputMode, OutputPin, PinDriver,
+};
 use crate::interrupt::asynch::HalIsrNotification;
 use crate::interrupt::InterruptType;
 use crate::peripheral::Peripheral;
@@ -410,7 +412,8 @@ impl<'d> SpiDriver<'d> {
         sdi: Option<impl Peripheral<P = impl InputPin> + 'd>,
         config: &config::DriverConfig,
     ) -> Result<Self, EspError> {
-        let max_transfer_size = Self::new_internal(SPI::device(), Option::<AnyIOPin>::None, sdo, sdi, config)?;
+        let max_transfer_size =
+            Self::new_internal(SPI::device(), Option::<AnyIOPin>::None, sdo, sdi, config)?;
 
         Ok(Self {
             host: SPI::device() as _,


### PR DESCRIPTION
Sometimes we only need MOSI pin of SPI peripheral, for example, for usage with WS2812 RGB led strip. This constructor adds more flexablily and keeps us from wasting pin without breaking any APIs.
Code tested on esp32-c3.
Example of usage:
https://github.com/okhsunrog/esp_pd_rs/blob/master/src/main.rs