### PR TITLE
fix clock usage in timer driver for idf 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * adc: legacy adc driver is now behind a feature flag `adc-oneshot-legacy` starting with >= ESP-IDF v5.0. For justification, look at https://github.com/espressif/esp-idf/issues/13938. (#433)
 * spi: cs_pre/post_trans_delay() config option included. (#266)
 ### Added
-* spi: added new_without_sclk SpiDriver constructor (#440)
 * rmt: `Symbol` now derives `Clone` and `Copy` (#386)
 * reset: restart() function (#383)
 * pcnt: Can now be used with esp32c6. (#407)
 * can: Frame flags enum (#411)
 * task: added MallocCap enum - Flag to indicate the capabilities of a Memory Region. (#419)
 * i2s: new I2sDriver implementation allowing for splited bidirectional i2s. (#435)
+* spi: added new_without_sclk SpiDriver constructor (#440)
 ### Fixed
 * esp32h2 builds: added missing hys_ctrl_mode field (#387)
 * rmt: FixedLengthSignal was broken, which led to failures in the neopixel/smartled examples, among other things. (#402)
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * task: Compatibility with ESP-iDF v5.3 (pre-release) - adding stack_alloc_caps to `ThreadSpawnConfiguration`. (#419)
 * i2s: Compatibility with ESP-IDF v5.3 (pre-release) - small internal adjustments to i2s (#419)
 * ledc: max_duty() method miscalulated in certain conditions. (#431)
+* timer: fix clock usage in timer driver used with ESP-IDF v5.x (#441)
 
 ## [0.43.1] - 2024-02-21
 * Fix - PinDriver state changes and the drop call invoked pull-ups to be enabled. New default behavior on init / state transition / drop is to not enable pull-ups. (#344). If users want to reduce power usage on unused pins, they now need to manually enable pull-ups on a pin. For example, call `core::mem::forget` on the PinDriver instance after setting the pull-ups.

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -77,7 +77,7 @@ pub mod config {
         PLL48,
         #[cfg(esp32c6)]
         PLL80,
-        #[cfg(any(esp32s2, esp32s3, esp32c2, esp32c3, esp32c6, esp32h2))]
+        #[cfg(not(esp32))]
         XTAL,
     }
 
@@ -122,7 +122,7 @@ pub mod config {
                 ClockSource::PLL80 => {
                     esp_idf_sys::soc_periph_tg_clk_src_legacy_t_TIMER_SRC_CLK_PLL_F80M
                 }
-                #[cfg(any(esp32s2, esp32s3, esp32c2, esp32c3, esp32c6))]
+                #[cfg(not(esp32))]
                 ClockSource::XTAL => esp_idf_sys::soc_periph_tg_clk_src_legacy_t_TIMER_SRC_CLK_XTAL,
             }
         }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -42,7 +42,7 @@ pub mod config {
         }
 
         #[must_use]
-        #[cfg(any(esp32s2, esp32s3, esp32c3))]
+        #[cfg(not(esp32))]
         pub fn xtal(mut self, xtal: bool) -> Self {
             self.xtal = xtal;
             self
@@ -66,6 +66,7 @@ pub mod config {
         }
     }
 
+    #[allow(clippy::upper_case_acronyms)]
     pub(crate) enum ClockSource {
         #[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
         APB,
@@ -133,6 +134,7 @@ pub trait Timer: Send {
 pub struct TimerDriver<'d> {
     timer: u8,
     divider: u32,
+    #[cfg(not(esp32))]
     xtal: bool,
     isr_registered: bool,
     _p: PhantomData<&'d mut ()>,
@@ -177,6 +179,7 @@ impl<'d> TimerDriver<'d> {
         Ok(Self {
             timer: ((TIMER::group() as u8) << 4) | (TIMER::index() as u8),
             divider: config.divider,
+            #[cfg(not(esp32))]
             xtal: config.xtal,
             isr_registered: false,
             _p: PhantomData,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -175,6 +175,8 @@ impl<'d> TimerDriver<'d> {
                     } else {
                         config::ClockSource::default().into()
                     },
+                    #[cfg(all(esp32, not(esp_idf_version_major = "4")))]
+                    clk_src: config::ClockSource::default().into(),
                 },
             )
         })?;
@@ -237,6 +239,10 @@ impl<'d> TimerDriver<'d> {
                 {
                     hz = 80_000_000 / self.divider;
                 }
+            }
+            #[cfg(esp32)]
+            {
+                hz = APB_CLK_FREQ / self.divider;
             }
         }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -68,39 +68,22 @@ pub mod config {
 
     #[cfg(not(esp_idf_version_major = "4"))]
     #[allow(clippy::upper_case_acronyms)]
+    #[derive(Default)]
     pub(crate) enum ClockSource {
         #[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
+        #[default]
         APB,
         #[cfg(esp32c2)]
+        #[default]
         PLL40,
         #[cfg(esp32h2)]
+        #[default]
         PLL48,
         #[cfg(esp32c6)]
+        #[default]
         PLL80,
         #[cfg(not(esp32))]
         XTAL,
-    }
-
-    #[cfg(not(esp_idf_version_major = "4"))]
-    impl Default for ClockSource {
-        fn default() -> Self {
-            #[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
-            {
-                Self::APB
-            }
-            #[cfg(esp32c2)]
-            {
-                Self::PLL40
-            }
-            #[cfg(esp32h2)]
-            {
-                Self::PLL48
-            }
-            #[cfg(esp32c6)]
-            {
-                Self::PLL80
-            }
-        }
     }
 
     #[cfg(not(esp_idf_version_major = "4"))]

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -102,6 +102,7 @@ pub mod config {
     }
 
     #[cfg(not(esp_idf_version_major = "4"))]
+    #[allow(clippy::from_over_into)]
     impl Into<esp_idf_sys::soc_periph_tg_clk_src_legacy_t> for ClockSource {
         fn into(self) -> esp_idf_sys::soc_periph_tg_clk_src_legacy_t {
             match self {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -66,6 +66,7 @@ pub mod config {
         }
     }
 
+    #[cfg(not(esp_idf_version_major = "4"))]
     #[allow(clippy::upper_case_acronyms)]
     pub(crate) enum ClockSource {
         #[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
@@ -80,6 +81,7 @@ pub mod config {
         XTAL,
     }
 
+    #[cfg(not(esp_idf_version_major = "4"))]
     impl Default for ClockSource {
         fn default() -> Self {
             #[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
@@ -135,7 +137,7 @@ pub trait Timer: Send {
 pub struct TimerDriver<'d> {
     timer: u8,
     divider: u32,
-    #[cfg(not(esp32))]
+    #[cfg(all(not(esp32), not(esp_idf_version_major = "4")))]
     xtal: bool,
     isr_registered: bool,
     _p: PhantomData<&'d mut ()>,
@@ -180,7 +182,7 @@ impl<'d> TimerDriver<'d> {
         Ok(Self {
             timer: ((TIMER::group() as u8) << 4) | (TIMER::index() as u8),
             divider: config.divider,
-            #[cfg(not(esp32))]
+            #[cfg(all(not(esp32), not(esp_idf_version_major = "4")))]
             xtal: config.xtal,
             isr_registered: false,
             _p: PhantomData,
@@ -200,6 +202,7 @@ impl<'d> TimerDriver<'d> {
 
         #[cfg(not(esp_idf_version_major = "4"))]
         {
+            #[cfg(not(esp32))]
             if self.xtal {
                 #[cfg(esp_idf_xtal_freq_24)]
                 {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -14,10 +14,11 @@ pub type TimerConfig = config::Config;
 
 /// Timer configuration
 pub mod config {
+
     #[derive(Copy, Clone)]
     pub struct Config {
         pub divider: u32,
-        #[cfg(any(esp32s2, esp32s3, esp32c3))]
+        #[cfg(not(esp32))]
         pub xtal: bool,
 
         /// Enable or disable counter reload function when alarm event occurs.
@@ -58,9 +59,67 @@ pub mod config {
         fn default() -> Self {
             Self {
                 divider: 80,
-                #[cfg(any(esp32s2, esp32s3, esp32c3))]
+                #[cfg(not(esp32))]
                 xtal: false,
                 auto_reload: false,
+            }
+        }
+    }
+
+    pub(crate) enum ClockSource {
+        #[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
+        APB,
+        #[cfg(esp32c2)]
+        PLL40,
+        #[cfg(esp32h2)]
+        PLL48,
+        #[cfg(esp32c6)]
+        PLL80,
+        #[cfg(any(esp32s2, esp32s3, esp32c2, esp32c3, esp32c6, esp32h2))]
+        XTAL,
+    }
+
+    impl Default for ClockSource {
+        fn default() -> Self {
+            #[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
+            {
+                Self::APB
+            }
+            #[cfg(esp32c2)]
+            {
+                Self::PLL40
+            }
+            #[cfg(esp32h2)]
+            {
+                Self::PLL48
+            }
+            #[cfg(esp32c6)]
+            {
+                Self::PLL80
+            }
+        }
+    }
+
+    #[cfg(not(esp_idf_version_major = "4"))]
+    impl Into<esp_idf_sys::soc_periph_tg_clk_src_legacy_t> for ClockSource {
+        fn into(self) -> esp_idf_sys::soc_periph_tg_clk_src_legacy_t {
+            match self {
+                #[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
+                ClockSource::APB => esp_idf_sys::soc_periph_tg_clk_src_legacy_t_TIMER_SRC_CLK_APB,
+                #[cfg(esp32c2)]
+                ClockSource::PLL40 => {
+                    esp_idf_sys::soc_periph_tg_clk_src_legacy_t_TIMER_SRC_CLK_PLL_F40M
+                }
+                #[cfg(esp32h2)]
+                ClockSource::PLL48 => {
+                    esp_idf_sys::soc_periph_tg_clk_src_legacy_t_TIMER_SRC_CLK_PLL_F48M
+                }
+                #[cfg(esp32c6)]
+                ClockSource::PLL80 => {
+                    esp_idf_sys::soc_periph_tg_clk_src_legacy_t_TIMER_SRC_CLK_PLL_F80M
+                }
+                #[cfg(any(esp32s2, esp32s3, esp32c2, esp32c3, esp32c6))]
+                ClockSource::XTAL => esp_idf_sys::soc_periph_tg_clk_src_legacy_t_TIMER_SRC_CLK_XTAL,
             }
         }
     }
@@ -74,6 +133,7 @@ pub trait Timer: Send {
 pub struct TimerDriver<'d> {
     timer: u8,
     divider: u32,
+    xtal: bool,
     isr_registered: bool,
     _p: PhantomData<&'d mut ()>,
 }
@@ -104,8 +164,12 @@ impl<'d> TimerDriver<'d> {
                     } else {
                         timer_src_clk_t_TIMER_SRC_CLK_APB
                     },
-                    #[cfg(not(esp_idf_version_major = "4"))]
-                    clk_src: 0,
+                    #[cfg(all(not(esp32), not(esp_idf_version_major = "4")))]
+                    clk_src: if config.xtal {
+                        config::ClockSource::XTAL.into()
+                    } else {
+                        config::ClockSource::default().into()
+                    },
                 },
             )
         })?;
@@ -113,6 +177,7 @@ impl<'d> TimerDriver<'d> {
         Ok(Self {
             timer: ((TIMER::group() as u8) << 4) | (TIMER::index() as u8),
             divider: config.divider,
+            xtal: config.xtal,
             isr_registered: false,
             _p: PhantomData,
         })
@@ -131,7 +196,41 @@ impl<'d> TimerDriver<'d> {
 
         #[cfg(not(esp_idf_version_major = "4"))]
         {
-            hz = APB_CLK_FREQ / self.divider;
+            if self.xtal {
+                #[cfg(esp_idf_xtal_freq_24)]
+                {
+                    hz = 24_000_000 / self.divider;
+                }
+                #[cfg(esp_idf_xtal_freq_26)]
+                {
+                    hz = 26_000_000 / self.divider;
+                }
+                #[cfg(esp_idf_xtal_freq_32)]
+                {
+                    hz = 32_000_000 / self.divider;
+                }
+                #[cfg(esp_idf_xtal_freq_40)]
+                {
+                    hz = 40_000_000 / self.divider;
+                }
+            } else {
+                #[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
+                {
+                    hz = APB_CLK_FREQ / self.divider;
+                }
+                #[cfg(esp32c2)] //PLL40
+                {
+                    hz = 40_000_000 / self.divider;
+                }
+                #[cfg(esp32h2)] //PLL48
+                {
+                    hz = 48_000_000 / self.divider;
+                }
+                #[cfg(esp32c6)] //PLL80
+                {
+                    hz = 80_000_000 / self.divider;
+                }
+            }
         }
 
         hz as _


### PR DESCRIPTION
Newer esp's (c2/h2/c6) don't use the apb clock as a default clock for the timer. They use different variants of the pll clock. Furthermore the general assumption that the xtal clock is always 40Mhz is not correct. This PR includes fixes for the TimeDriver in this respect.

closes #426 