### PR TITLE
Fix timer and gpio config for ESP IDF 4.4.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         target:
           - riscv32imc-esp-espidf
+          - riscv32imac-esp-espidf
           - xtensa-esp32-espidf
           - xtensa-esp32s2-espidf
           - xtensa-esp32s3-espidf
@@ -87,6 +88,7 @@ jobs:
           chmod a+x $HOME/.cargo/bin/ldproxy
 
       - name: Build | Examples
+        if: matrix.target != 'riscv32imac-esp-espidf'
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1448,7 +1448,7 @@ fn gpio_reset_without_pull(pin: gpio_num_t) -> Result<(), EspError> {
         pull_up_en: esp_idf_sys::gpio_pullup_t_GPIO_PULLUP_DISABLE,
         pull_down_en: esp_idf_sys::gpio_pulldown_t_GPIO_PULLDOWN_DISABLE,
         intr_type: esp_idf_sys::gpio_int_type_t_GPIO_INTR_DISABLE,
-        #[cfg(esp32h2)]
+        #[cfg(all(esp32h2, not(esp_idf_version_major = "4")))]
         hys_ctrl_mode: esp_idf_sys::gpio_hys_ctrl_mode_t_GPIO_HYS_SOFT_DISABLE,
     };
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -146,7 +146,7 @@ impl<'d> TimerDriver<'d> {
                     },
                     intr_type: timer_intr_mode_t_TIMER_INTR_LEVEL,
                     divider: config.divider,
-                    #[cfg(all(any(esp32s2, esp32s3, esp32c3), esp_idf_version_major = "4"))]
+                    #[cfg(all(not(esp32), esp_idf_version_major = "4"))]
                     clk_src: if config.xtal {
                         timer_src_clk_t_TIMER_SRC_CLK_XTAL
                     } else {


### PR DESCRIPTION
Timer & GPIO configs are both broken for ESP IDF 4.4 and the `riscv32imac-esp-espidf` target.
