### PR TITLE
SD Card driver; SD Card host drivers (SPI and SDMMC)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ default = ["std", "binstart"]
 std = ["alloc", "esp-idf-sys/std"]
 alloc = []
 nightly = []
+experimental = []
 wake-from-isr = [] # Only enable if you plan to use the `edge-executor` crate
 embassy-sync = [] # For now, the dependecy on the `embassy-sync` crate is non-optional, but this might change in future
 # Temporary, until (https://github.com/espressif/esp-idf/issues/13938) is addressed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@ pub mod prelude;
 pub mod reset;
 pub mod rmt;
 pub mod rom;
+#[cfg(feature = "experimental")]
+pub mod sd;
 pub mod spi;
 pub mod sys;
 pub mod task;

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -11,6 +11,8 @@ use crate::modem;
 #[cfg(any(esp32, esp32s2, esp32s3, esp32c6))]
 use crate::pcnt;
 use crate::rmt;
+#[cfg(all(esp_idf_soc_sdmmc_host_supported, feature = "experimental"))]
+use crate::sd;
 use crate::spi;
 #[cfg(any(
     all(
@@ -80,6 +82,10 @@ pub struct Peripherals {
     #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
     pub mac: mac::MAC,
     pub modem: modem::Modem,
+    #[cfg(all(esp_idf_soc_sdmmc_host_supported, feature = "experimental"))]
+    pub sdmmc0: sd::mmc::SDMMC0,
+    #[cfg(all(esp_idf_soc_sdmmc_host_supported, feature = "experimental"))]
+    pub sdmmc1: sd::mmc::SDMMC1,
     // TODO: Check the timer story for c2, h2, c5, c6, and p4
     pub timer00: timer::TIMER00,
     #[cfg(any(esp32, esp32s2, esp32s3))]
@@ -177,6 +183,10 @@ impl Peripherals {
             #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
             mac: mac::MAC::new(),
             modem: modem::Modem::new(),
+            #[cfg(all(esp_idf_soc_sdmmc_host_supported, feature = "experimental"))]
+            sdmmc0: sd::mmc::SDMMC0::new(),
+            #[cfg(all(esp_idf_soc_sdmmc_host_supported, feature = "experimental"))]
+            sdmmc1: sd::mmc::SDMMC1::new(),
             timer00: timer::TIMER00::new(),
             #[cfg(any(esp32, esp32s2, esp32s3))]
             timer01: timer::TIMER01::new(),

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -11,13 +11,12 @@ use spi::SdSpiHostDriver;
 pub mod mmc;
 pub mod spi;
 
-const _HOST_FLAG_SPI: u32 = 1 << 3;
-const _HOST_FLAG_DEINIT_ARG: u32 = 1 << 5;
+const _SDMMC_HOST_FLAG_SPI: u32 = 1 << 3;
+const _SDMMC_HOST_FLAG_DDR: u32 = 1 << 4;
+const _SDMMC_HOST_FLAG_DEINIT_ARG: u32 = 1 << 5;
 
-#[cfg(esp_idf_soc_sdmmc_host_supported)]
-pub type SdMmcConfiguration = config::SdMmcConfiguration;
+pub type SdCardConfiguration = config::Configuration;
 
-#[cfg(esp_idf_soc_sdmmc_host_supported)]
 pub mod config {
     #[cfg(not(any(
         esp_idf_version_major = "4",
@@ -26,11 +25,13 @@ pub mod config {
     )))] // For ESP-IDF v5.2 and later
     use crate::sys::*;
 
+    /// (SD-MMC only): Input delay phase
     #[cfg(not(any(
         esp_idf_version_major = "4",
         all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
         all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
     )))] // For ESP-IDF v5.2 and later
+    #[non_exhaustive]
     #[derive(Debug, Copy, Clone, Eq, PartialEq)]
     pub enum DelayPhase {
         Phase0 = sdmmc_delay_phase_t_SDMMC_DELAY_PHASE_0 as isize,
@@ -57,41 +58,43 @@ pub mod config {
         }
     }
 
-    #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
-    pub enum Speed {
-        #[default]
-        S20Mhz,
-        S40Mhz,
-    }
-
-    impl Speed {
-        pub const fn as_khz(&self) -> i32 {
-            match self {
-                Self::S20Mhz => 20000,
-                Self::S40Mhz => 40000,
-            }
-        }
-    }
-
+    /// SD-Card voltage
+    #[non_exhaustive]
     #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
     pub enum Voltage {
+        /// (ESP32P4 only)
+        /// Use 1.8V IO voltage for UHS-I speed
+        /// This means the user has to provide an external LDO power supply
+        /// or to enable and configure an internal LDO via the `sdkconfig` setting
+        /// "SD/MMC Example Configuration -> SD power supply comes from internal LDO IO"
+        V1P8,
+        /// Use 3.3V IO voltage for speeds below UHS-I
+        /// The only supported conf for MCUs other than ESP32P4
         #[default]
         V3P3,
     }
 
     impl Voltage {
-        pub const fn as_volts(&self) -> f32 {
+        pub(crate) const fn as_volts(&self) -> f32 {
             match self {
+                Self::V1P8 => 1.8,
                 Self::V3P3 => 3.3,
             }
         }
     }
 
-    /// Configuration relevant when the SD-Card driver is instantiated with the SD-MMC Host driver
-    pub struct SdMmcConfiguration {
+    /// Configuration for the SD-Card driver
+    #[non_exhaustive]
+    pub struct Configuration {
+        /// Command timeout in milliseconds. Default is 0 (no timeout)
         pub command_timeout_ms: u32,
+        /// SD-Card IO voltage. Default is 3.3V;
+        /// 1.8V might only be necessary for ESP32P4 and UHS-I speeds
         pub io_voltage: Voltage,
-        pub speed: Speed,
+        /// SD-Card speed in kHz. Default is 20000 kHz (20 MHz)
+        /// Maximum speed is usually 40000 kHz (40 MHz)
+        /// Speeds lower than 20000 kHz can also be used
+        pub speed_khz: u32,
         #[cfg(not(any(
             esp_idf_version_major = "4",
             all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
@@ -100,12 +103,13 @@ pub mod config {
         pub input_delay_phase: DelayPhase,
     }
 
-    impl SdMmcConfiguration {
+    impl Configuration {
+        /// Create a new configuration with default values
         pub const fn new() -> Self {
             Self {
                 command_timeout_ms: 0,
                 io_voltage: Voltage::V3P3,
-                speed: Speed::S20Mhz,
+                speed_khz: 20000,
                 #[cfg(not(any(
                     esp_idf_version_major = "4",
                     all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
@@ -116,7 +120,7 @@ pub mod config {
         }
     }
 
-    impl Default for SdMmcConfiguration {
+    impl Default for Configuration {
         fn default() -> Self {
             Self::new()
         }
@@ -127,7 +131,7 @@ pub mod config {
 ///
 /// This driver is used to interface with an SD-Card by wrapping one of the two SD Host drivers:
 /// - SD-SPI Host driver (`SdSpiHostDriver`)
-/// - SD-MMC Host driver (`SdMmcHostDriver`) - on MCUs that do have an SD-MMC peripheral
+/// - SD-MMC Host driver (`SdMmcHostDriver`) - on MCUs that do have an SD-MMC peripheral (ESP32, ESP32S3 and ESP32P4)
 ///
 /// The interface allows reading, writing and erasing sectors, as well as reading and writing arbitrary-length bytes.
 ///
@@ -144,7 +148,7 @@ impl<T> SdCardDriver<T> {
     }
 
     // TODO: Implement the SD-Card API here, i.e. read/write/erase sectors, as well as
-    // read/write of arbitrary-length bytes
+    // read/write of arbitrary-length bytes.
 }
 
 impl<'d, T> SdCardDriver<SdSpiHostDriver<'d, T>>
@@ -152,12 +156,15 @@ where
     T: Borrow<SpiDriver<'d>>,
 {
     /// Create a new SD-Card driver using the SD-SPI host driver instantiated with one of the SPI peripherals
-    pub fn new_spi(host: SdSpiHostDriver<'d, T>) -> Result<Self, EspError> {
+    pub fn new_spi(
+        host: SdSpiHostDriver<'d, T>,
+        configuration: &config::Configuration,
+    ) -> Result<Self, EspError> {
         let configuration = sdmmc_host_t {
-            flags: _HOST_FLAG_SPI | _HOST_FLAG_DEINIT_ARG,
+            flags: _SDMMC_HOST_FLAG_SPI | _SDMMC_HOST_FLAG_DEINIT_ARG,
             slot: host.handle() as _,
-            max_freq_khz: 20000,    // n/a for SD-SPI
-            io_voltage: 3.3f32,     // n/a for SD-SPI
+            max_freq_khz: configuration.speed_khz as _,
+            io_voltage: configuration.io_voltage.as_volts(),
             init: Some(sdspi_host_init),
             set_bus_width: None,
             get_bus_width: None,
@@ -180,14 +187,14 @@ where
                 all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
                 all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
             )))]    // For ESP-IDF v5.2 and later
-            input_delay_phase: sdmmc_delay_phase_t_SDMMC_DELAY_PHASE_0,
+            input_delay_phase: sdmmc_delay_phase_t_SDMMC_DELAY_PHASE_0, // No-op for SD-SPI
             #[cfg(not(any(
                 esp_idf_version_major = "4",
                 all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
                 all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
             )))]   // For ESP-IDF v5.2 and later
             set_input_delay: None,
-            command_timeout_ms: 0,
+            command_timeout_ms: configuration.command_timeout_ms as _,
             #[cfg(not(any(
                 esp_idf_version_major = "4",
                 all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
@@ -223,15 +230,18 @@ where
 impl<'d> SdCardDriver<SdMmcHostDriver<'d>> {
     /// Create a new SD-Card driver using the SD-MMC Host driver instantiated with one of the two SD-MMC peripheral slots
     pub fn new_mmc(
-        configuration: &config::SdMmcConfiguration,
         host: SdMmcHostDriver<'d>,
+        configuration: &config::Configuration,
     ) -> Result<Self, EspError> {
         let configuration = sdmmc_host_t {
-            flags: _HOST_FLAG_DEINIT_ARG
-                | ((1 | if host.width() > 1 { host.width() - 1 } else { 0 }) as u32)
-                | 0, // TODO SDMMC_HOST_FLAG_DDR,
+            flags: _SDMMC_HOST_FLAG_DEINIT_ARG
+                | _SDMMC_HOST_FLAG_DDR
+                // Bits 0 - 2 are flags for data widths 1, 4 and 8 respectively
+                // Set the bit corresponding to our width and all smaller widths
+                // in case the card does not support our width, but a smaller one only
+                | (1 | (host.width() - 1)) as u32,
             slot: host.slot_no() as _,
-            max_freq_khz: configuration.speed.as_khz(),
+            max_freq_khz: configuration.speed_khz as _,
             io_voltage: configuration.io_voltage.as_volts(),
             init: Some(sdmmc_host_init),
             set_bus_width: Some(sdmmc_host_set_bus_width),

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -3,7 +3,6 @@ use core::borrow::Borrow;
 use crate::spi::SpiDriver;
 use crate::sys::*;
 
-use config::{Speed, Voltage};
 #[cfg(esp_idf_soc_sdmmc_host_supported)]
 use mmc::SdMmcHostDriver;
 use spi::SdSpiHostDriver;
@@ -157,8 +156,8 @@ where
         let configuration = sdmmc_host_t {
             flags: _HOST_FLAG_SPI | _HOST_FLAG_DEINIT_ARG,
             slot: host.handle() as _,
-            max_freq_khz: Speed::default().as_khz(),    // n/a for SD-SPI
-            io_voltage: Voltage::default().as_volts(),  // n/a for SD-SPI
+            max_freq_khz: 20000,    // n/a for SD-SPI
+            io_voltage: 3.3f32,     // n/a for SD-SPI
             init: Some(sdspi_host_init),
             set_bus_width: None,
             get_bus_width: None,

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -44,7 +44,7 @@ pub mod config {
         esp_idf_version_major = "4",
         all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
         all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
-    )))] // For ESP-IDF v4.x, v5.0, and v5.1
+    )))] // For ESP-IDF v5.2 and later
     impl From<sdmmc_delay_phase_t> for DelayPhase {
         fn from(phase: sdmmc_delay_phase_t) -> Self {
             #[allow(non_upper_case_globals)]
@@ -75,7 +75,7 @@ pub mod config {
     }
 
     impl Voltage {
-        pub(crate) const fn as_volts(&self) -> f32 {
+        pub(crate) const fn as_native(&self) -> f32 {
             match self {
                 Self::V1P8 => 1.8,
                 Self::V3P3 => 3.3,
@@ -164,7 +164,7 @@ where
             flags: _SDMMC_HOST_FLAG_SPI | _SDMMC_HOST_FLAG_DEINIT_ARG,
             slot: host.handle() as _,
             max_freq_khz: configuration.speed_khz as _,
-            io_voltage: configuration.io_voltage.as_volts(),
+            io_voltage: configuration.io_voltage.as_native(),
             init: Some(sdspi_host_init),
             set_bus_width: None,
             get_bus_width: None,
@@ -240,9 +240,9 @@ impl<'d> SdCardDriver<SdMmcHostDriver<'d>> {
                 // Set the bit corresponding to our width and all smaller widths
                 // in case the card does not support our width, but a smaller one only
                 | (1 | (host.width() - 1)) as u32,
-            slot: host.slot_no() as _,
+            slot: host.slot() as _,
             max_freq_khz: configuration.speed_khz as _,
-            io_voltage: configuration.io_voltage.as_volts(),
+            io_voltage: configuration.io_voltage.as_native(),
             init: Some(sdmmc_host_init),
             set_bus_width: Some(sdmmc_host_set_bus_width),
             get_bus_width: Some(sdmmc_host_get_slot_width),

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -1,0 +1,292 @@
+use core::borrow::Borrow;
+
+use crate::spi::SpiDriver;
+use crate::sys::*;
+
+use config::{Speed, Voltage};
+#[cfg(esp_idf_soc_sdmmc_host_supported)]
+use mmc::SdMmcHostDriver;
+use spi::SdSpiHostDriver;
+
+#[cfg(esp_idf_soc_sdmmc_host_supported)]
+pub mod mmc;
+pub mod spi;
+
+const _HOST_FLAG_SPI: u32 = 1 << 3;
+const _HOST_FLAG_DEINIT_ARG: u32 = 1 << 5;
+
+#[cfg(esp_idf_soc_sdmmc_host_supported)]
+pub type SdMmcConfiguration = config::SdMmcConfiguration;
+
+#[cfg(esp_idf_soc_sdmmc_host_supported)]
+pub mod config {
+    #[cfg(not(any(
+        esp_idf_version_major = "4",
+        all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+        all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+    )))] // For ESP-IDF v5.2 and later
+    use crate::sys::*;
+
+    #[cfg(not(any(
+        esp_idf_version_major = "4",
+        all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+        all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+    )))] // For ESP-IDF v5.2 and later
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+    pub enum DelayPhase {
+        Phase0 = sdmmc_delay_phase_t_SDMMC_DELAY_PHASE_0 as isize,
+        Phase1 = sdmmc_delay_phase_t_SDMMC_DELAY_PHASE_1 as isize,
+        Phase2 = sdmmc_delay_phase_t_SDMMC_DELAY_PHASE_2 as isize,
+        Phase3 = sdmmc_delay_phase_t_SDMMC_DELAY_PHASE_3 as isize,
+    }
+
+    #[cfg(not(any(
+        esp_idf_version_major = "4",
+        all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+        all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+    )))] // For ESP-IDF v4.x, v5.0, and v5.1
+    impl From<sdmmc_delay_phase_t> for DelayPhase {
+        fn from(phase: sdmmc_delay_phase_t) -> Self {
+            #[allow(non_upper_case_globals)]
+            match phase {
+                sdmmc_delay_phase_t_SDMMC_DELAY_PHASE_0 => Self::Phase0,
+                sdmmc_delay_phase_t_SDMMC_DELAY_PHASE_1 => Self::Phase1,
+                sdmmc_delay_phase_t_SDMMC_DELAY_PHASE_2 => Self::Phase2,
+                sdmmc_delay_phase_t_SDMMC_DELAY_PHASE_3 => Self::Phase3,
+                _ => panic!("Invalid delay phase"),
+            }
+        }
+    }
+
+    #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+    pub enum Speed {
+        #[default]
+        S20Mhz,
+        S40Mhz,
+    }
+
+    impl Speed {
+        pub const fn as_khz(&self) -> i32 {
+            match self {
+                Self::S20Mhz => 20000,
+                Self::S40Mhz => 40000,
+            }
+        }
+    }
+
+    #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+    pub enum Voltage {
+        #[default]
+        V3P3,
+    }
+
+    impl Voltage {
+        pub const fn as_volts(&self) -> f32 {
+            match self {
+                Self::V3P3 => 3.3,
+            }
+        }
+    }
+
+    /// Configuration relevant when the SD-Card driver is instantiated with the SD-MMC Host driver
+    pub struct SdMmcConfiguration {
+        pub command_timeout_ms: u32,
+        pub io_voltage: Voltage,
+        pub speed: Speed,
+        #[cfg(not(any(
+            esp_idf_version_major = "4",
+            all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+            all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+        )))] // For ESP-IDF v5.2 and later
+        pub input_delay_phase: DelayPhase,
+    }
+
+    impl SdMmcConfiguration {
+        pub const fn new() -> Self {
+            Self {
+                command_timeout_ms: 0,
+                io_voltage: Voltage::V3P3,
+                speed: Speed::S20Mhz,
+                #[cfg(not(any(
+                    esp_idf_version_major = "4",
+                    all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+                    all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+                )))] // For ESP-IDF v5.2 and later
+                input_delay_phase: DelayPhase::Phase0,
+            }
+        }
+    }
+
+    impl Default for SdMmcConfiguration {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+}
+
+/// A high-level SD-Card driver.
+///
+/// This driver is used to interface with an SD-Card by wrapping one of the two SD Host drivers:
+/// - SD-SPI Host driver (`SdSpiHostDriver`)
+/// - SD-MMC Host driver (`SdMmcHostDriver`) - on MCUs that do have an SD-MMC peripheral
+///
+/// The interface allows reading, writing and erasing sectors, as well as reading and writing arbitrary-length bytes.
+///
+/// Currently, all interaction with the SD-Card driver is via the native, unsafe `sys::sdmmc_*` functions.
+pub struct SdCardDriver<T> {
+    _host: T,
+    card: sdmmc_card_t,
+}
+
+impl<T> SdCardDriver<T> {
+    /// Get a reference to the SD-Card native structure.
+    pub fn card(&self) -> &sdmmc_card_t {
+        &self.card
+    }
+
+    // TODO: Implement the SD-Card API here, i.e. read/write/erase sectors, as well as
+    // read/write of arbitrary-length bytes
+}
+
+impl<'d, T> SdCardDriver<SdSpiHostDriver<'d, T>>
+where
+    T: Borrow<SpiDriver<'d>>,
+{
+    /// Create a new SD-Card driver using the SD-SPI host driver instantiated with one of the SPI peripherals
+    pub fn new_spi(host: SdSpiHostDriver<'d, T>) -> Result<Self, EspError> {
+        let configuration = sdmmc_host_t {
+            flags: _HOST_FLAG_SPI | _HOST_FLAG_DEINIT_ARG,
+            slot: host.handle() as _,
+            max_freq_khz: Speed::default().as_khz(),    // n/a for SD-SPI
+            io_voltage: Voltage::default().as_volts(),  // n/a for SD-SPI
+            init: Some(sdspi_host_init),
+            set_bus_width: None,
+            get_bus_width: None,
+            set_bus_ddr_mode: None,
+            set_card_clk: Some(sdspi_host_set_card_clk),
+            set_cclk_always_on: None,
+            do_transaction: Some(sdspi_host_do_transaction),
+            __bindgen_anon_1: sdmmc_host_t__bindgen_ty_1 {
+                deinit_p: Some(sdspi_host_remove_device),
+            },
+            io_int_enable: Some(sdspi_host_io_int_enable),
+            io_int_wait: Some(sdspi_host_io_int_wait),
+            #[cfg(not(any(
+                esp_idf_version_major = "4",
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+            )))]    // For ESP-IDF v5.1 and later
+            get_real_freq: Some(sdspi_host_get_real_freq),
+            #[cfg(not(any(
+                esp_idf_version_major = "4",
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+            )))]    // For ESP-IDF v5.2 and later
+            input_delay_phase: sdmmc_delay_phase_t_SDMMC_DELAY_PHASE_0,
+            #[cfg(not(any(
+                esp_idf_version_major = "4",
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+            )))]   // For ESP-IDF v5.2 and later
+            set_input_delay: None,
+            command_timeout_ms: 0,
+            #[cfg(not(any(
+                esp_idf_version_major = "4",
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "2"),
+            )))]   // For ESP-IDF v5.3 and later
+            dma_aligned_buffer: core::ptr::null_mut(),
+            #[cfg(not(any(
+                esp_idf_version_major = "4",
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "2"),
+            )))]   // For ESP-IDF v5.3 and later
+            get_dma_info: None,
+            #[cfg(not(any(
+                esp_idf_version_major = "4",
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "2"),
+            )))]   // For ESP-IDF v5.3 and later
+            pwr_ctrl_handle: core::ptr::null_mut() as _,
+        };
+
+        let mut card: sdmmc_card_t = Default::default();
+
+        esp!(unsafe { sdmmc_card_init(&configuration, &mut card) })?;
+
+        Ok(Self { _host: host, card })
+    }
+}
+
+#[cfg(esp_idf_soc_sdmmc_host_supported)]
+impl<'d> SdCardDriver<SdMmcHostDriver<'d>> {
+    /// Create a new SD-Card driver using the SD-MMC Host driver instantiated with one of the two SD-MMC peripheral slots
+    pub fn new_mmc(
+        configuration: &config::SdMmcConfiguration,
+        host: SdMmcHostDriver<'d>,
+    ) -> Result<Self, EspError> {
+        let configuration = sdmmc_host_t {
+            flags: _HOST_FLAG_DEINIT_ARG
+                | ((1 | if host.width() > 1 { host.width() - 1 } else { 0 }) as u32)
+                | 0, // TODO SDMMC_HOST_FLAG_DDR,
+            slot: host.slot_no() as _,
+            max_freq_khz: configuration.speed.as_khz(),
+            io_voltage: configuration.io_voltage.as_volts(),
+            init: Some(sdmmc_host_init),
+            set_bus_width: Some(sdmmc_host_set_bus_width),
+            get_bus_width: Some(sdmmc_host_get_slot_width),
+            set_bus_ddr_mode: Some(sdmmc_host_set_bus_ddr_mode),
+            set_card_clk: Some(sdmmc_host_set_card_clk),
+            set_cclk_always_on: Some(sdmmc_host_set_cclk_always_on),
+            do_transaction: Some(sdmmc_host_do_transaction),
+            __bindgen_anon_1: sdmmc_host_t__bindgen_ty_1 {
+                deinit: Some(sdmmc_host_deinit),
+            },
+            io_int_enable: Some(sdmmc_host_io_int_enable),
+            io_int_wait: Some(sdmmc_host_io_int_wait),
+            get_real_freq: Some(sdmmc_host_get_real_freq),
+            #[cfg(not(any(
+                esp_idf_version_major = "4",
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+             )))] // For ESP-IDF v5.2 and later            
+            input_delay_phase: sdmmc_delay_phase_t_SDMMC_DELAY_PHASE_0,
+            #[cfg(not(any(
+                esp_idf_version_major = "4",
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+             )))] // For ESP-IDF v5.2 and later            
+            set_input_delay: Some(sdmmc_host_set_input_delay),
+            command_timeout_ms: configuration.command_timeout_ms as _,
+            #[cfg(not(any(
+                esp_idf_version_major = "4",
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "2"),
+            )))]   // For ESP-IDF v5.3 and later
+            dma_aligned_buffer: core::ptr::null_mut(),
+            #[cfg(not(any(
+                esp_idf_version_major = "4",
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "2"),
+            )))]   // For ESP-IDF v5.3 and later
+            get_dma_info: None,
+            #[cfg(not(any(
+                esp_idf_version_major = "4",
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "2"),
+            )))]   // For ESP-IDF v5.3 and later
+            pwr_ctrl_handle: core::ptr::null_mut() as _,
+        };
+
+        let mut card: sdmmc_card_t = Default::default();
+
+        esp!(unsafe { sdmmc_card_init(&configuration, &mut card) })?;
+
+        Ok(Self { _host: host, card })
+    }
+}

--- a/src/sd/mmc.rs
+++ b/src/sd/mmc.rs
@@ -2,9 +2,7 @@ use core::marker::PhantomData;
 use core::ops::Deref;
 use core::sync::atomic::{AtomicU8, Ordering};
 
-#[cfg(not(esp_idf_soc_sdmmc_use_gpio_matrix))]
-use crate::gpio;
-use crate::gpio::{InputPin, OutputPin};
+use crate::gpio::{self, InputPin, OutputPin};
 use crate::peripheral::Peripheral;
 use crate::sys::*;
 

--- a/src/sd/mmc.rs
+++ b/src/sd/mmc.rs
@@ -21,7 +21,7 @@ pub trait SdMmc {
     fn slot() -> u8;
 }
 
-/// SD-MMC Host driver (per slot) or SD Cards supporting the MMC protocol.
+/// SD-MMC Host driver (per slot) for SD Cards supporting the MMC protocol.
 pub struct SdMmcHostDriver<'d> {
     slot: u8,
     width: u8,

--- a/src/sd/mmc.rs
+++ b/src/sd/mmc.rs
@@ -413,7 +413,7 @@ impl<'d> SdMmcHostDriver<'d> {
         })
     }
 
-    pub(crate) fn slot_no(&self) -> u8 {
+    pub(crate) fn slot(&self) -> u8 {
         self.slot
     }
 

--- a/src/sd/mmc.rs
+++ b/src/sd/mmc.rs
@@ -32,7 +32,7 @@ impl<'d> SdMmcHostDriver<'d> {
     /// Create a new driver for the provided slot peripheral with data line width 1.
     #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
     #[allow(clippy::too_many_arguments)]
-    pub fn new_width_1<S: SdMmc>(
+    pub fn new_1bit<S: SdMmc>(
         slot: impl Peripheral<P = S> + 'd,
         cmd: impl Peripheral<P = impl OutputPin> + 'd,
         clk: impl Peripheral<P = impl OutputPin> + 'd,
@@ -48,7 +48,7 @@ impl<'d> SdMmcHostDriver<'d> {
     /// Create a new driver for the provided slot peripheral with data line width 4.
     #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
     #[allow(clippy::too_many_arguments)]
-    pub fn new_width_4<S: SdMmc>(
+    pub fn new_4bit<S: SdMmc>(
         slot: impl Peripheral<P = S> + 'd,
         cmd: impl Peripheral<P = impl OutputPin> + 'd,
         clk: impl Peripheral<P = impl OutputPin> + 'd,
@@ -80,7 +80,7 @@ impl<'d> SdMmcHostDriver<'d> {
     /// Create a new driver for the provided slot peripheral with data line width 8.
     #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
     #[allow(clippy::too_many_arguments)]
-    pub fn new_width_8<S: SdMmc>(
+    pub fn new_8bit<S: SdMmc>(
         slot: impl Peripheral<P = S> + 'd,
         cmd: impl Peripheral<P = impl OutputPin> + 'd,
         clk: impl Peripheral<P = impl OutputPin> + 'd,

--- a/src/sd/mmc.rs
+++ b/src/sd/mmc.rs
@@ -1,0 +1,287 @@
+use core::marker::PhantomData;
+use core::ops::Deref;
+use core::sync::atomic::{AtomicU8, Ordering};
+
+#[cfg(not(esp_idf_soc_sdmmc_use_gpio_matrix))]
+use crate::gpio;
+use crate::gpio::{InputPin, OutputPin};
+use crate::peripheral::Peripheral;
+use crate::sys::*;
+
+/// Indicates that card detect line is not used
+const SDMMC_SLOT_NO_CD: i32 = -1;
+/// Indicates that write protect line is not used
+const SDMMC_SLOT_NO_WP: i32 = -1;
+
+static USED_SLOTS: AtomicU8 = AtomicU8::new(0);
+static USED_SLOTS_CS: crate::task::CriticalSection = crate::task::CriticalSection::new();
+
+/// SDMMC host slot peripheral
+pub trait SdMmc {
+    fn slot() -> u8;
+}
+
+/// SD-MMC Host driver (per slot) or SD Cards supporting the MMC protocol.
+pub struct SdMmcHostDriver<'d> {
+    slot: u8,
+    width: u8,
+    _p: PhantomData<&'d mut ()>,
+}
+
+impl<'d> SdMmcHostDriver<'d> {
+    /// Create a new driver for the provided slot peripheral with data line width 1.
+    #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_width_1<S: SdMmc>(
+        slot: impl Peripheral<P = S> + 'd,
+        cmd: impl Peripheral<P = impl OutputPin> + 'd,
+        clk: impl Peripheral<P = impl OutputPin> + 'd,
+        d0: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        cd: Option<impl Peripheral<P = impl InputPin> + 'd>,
+        wp: Option<impl Peripheral<P = impl InputPin> + 'd>,
+    ) -> Result<Self, EspError> {
+        Self::new_internal(
+            1, slot, cmd, clk, d0, None, None, None, None, None, None, None, cd, wp,
+        )
+    }
+
+    /// Create a new driver for the provided slot peripheral with data line width 4.
+    #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_width_4<S: SdMmc>(
+        slot: impl Peripheral<P = S> + 'd,
+        cmd: impl Peripheral<P = impl OutputPin> + 'd,
+        clk: impl Peripheral<P = impl OutputPin> + 'd,
+        d0: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        d1: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        d2: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        d3: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        cd: Option<impl Peripheral<P = impl InputPin> + 'd>,
+        wp: Option<impl Peripheral<P = impl InputPin> + 'd>,
+    ) -> Result<Self, EspError> {
+        Self::new_internal(
+            4,
+            slot,
+            cmd,
+            clk,
+            d0,
+            Some(d1),
+            Some(d2),
+            Some(d3),
+            None,
+            None,
+            None,
+            None,
+            cd,
+            wp,
+        )
+    }
+
+    /// Create a new driver for the provided slot peripheral with data line width 8.
+    #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_width_8<S: SdMmc>(
+        slot: impl Peripheral<P = S> + 'd,
+        cmd: impl Peripheral<P = impl OutputPin> + 'd,
+        clk: impl Peripheral<P = impl OutputPin> + 'd,
+        d0: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        d1: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        d2: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        d3: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        d4: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        d5: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        d6: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        d7: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        cd: Option<impl Peripheral<P = impl InputPin> + 'd>,
+        wp: Option<impl Peripheral<P = impl InputPin> + 'd>,
+    ) -> Result<Self, EspError> {
+        Self::new_internal(
+            8,
+            slot,
+            cmd,
+            clk,
+            d0,
+            Some(d1),
+            Some(d2),
+            Some(d3),
+            Some(d4),
+            Some(d5),
+            Some(d6),
+            Some(d7),
+            cd,
+            wp,
+        )
+    }
+
+    /// Create a new driver for slot 0 of the SD-MMC peripheral.
+    #[cfg(not(esp_idf_soc_sdmmc_use_gpio_matrix))]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_slot_0(
+        slot0: impl Peripheral<P = SDMMC0> + 'd,
+        cmd: impl Peripheral<P = gpio::Gpio11> + 'd,
+        clk: impl Peripheral<P = gpio::Gpio6> + 'd,
+        d0: impl Peripheral<P = gpio::Gpio7> + 'd,
+        d1: impl Peripheral<P = gpio::Gpio8> + 'd,
+        d2: impl Peripheral<P = gpio::Gpio9> + 'd,
+        d3: impl Peripheral<P = gpio::Gpio10> + 'd,
+        d4: impl Peripheral<P = gpio::Gpio16> + 'd,
+        d5: impl Peripheral<P = gpio::Gpio17> + 'd,
+        d6: impl Peripheral<P = gpio::Gpio15> + 'd,
+        d7: impl Peripheral<P = gpio::Gpio18> + 'd,
+        cd: Option<impl Peripheral<P = impl InputPin> + 'd>,
+        wp: Option<impl Peripheral<P = impl InputPin> + 'd>,
+    ) -> Result<Self, EspError> {
+        Self::new_internal(
+            8,
+            slot0,
+            cmd,
+            clk,
+            d0,
+            Some(d1),
+            Some(d2),
+            Some(d3),
+            Some(d4),
+            Some(d5),
+            Some(d6),
+            Some(d7),
+            cd,
+            wp,
+        )
+    }
+
+    /// Create a new driver for slot 1 of the SD-MMC peripheral.
+    #[cfg(not(esp_idf_soc_sdmmc_use_gpio_matrix))]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_slot_1(
+        slot1: impl Peripheral<P = SDMMC1> + 'd,
+        cmd: impl Peripheral<P = gpio::Gpio15> + 'd,
+        clk: impl Peripheral<P = gpio::Gpio14> + 'd,
+        d0: impl Peripheral<P = gpio::Gpio2> + 'd,
+        d1: impl Peripheral<P = gpio::Gpio4> + 'd,
+        d2: impl Peripheral<P = gpio::Gpio12> + 'd,
+        d3: impl Peripheral<P = gpio::Gpio13> + 'd,
+        cd: Option<impl Peripheral<P = gpio::Gpio34> + 'd>,
+        wp: Option<impl Peripheral<P = gpio::Gpio35> + 'd>,
+    ) -> Result<Self, EspError> {
+        Self::new_internal(
+            4,
+            slot1,
+            cmd,
+            clk,
+            d0,
+            Some(d1),
+            Some(d2),
+            Some(d3),
+            Option::<gpio::AnyIOPin>::None,
+            Option::<gpio::AnyIOPin>::None,
+            Option::<gpio::AnyIOPin>::None,
+            Option::<gpio::AnyIOPin>::None,
+            cd,
+            wp,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_internal<S: SdMmc>(
+        width: u8,
+        _slot: impl Peripheral<P = S> + 'd,
+        _cmd: impl Peripheral<P = impl OutputPin> + 'd,
+        _clk: impl Peripheral<P = impl OutputPin> + 'd,
+        _d0: impl Peripheral<P = impl InputPin + OutputPin> + 'd,
+        _d1: Option<impl Peripheral<P = impl InputPin + OutputPin> + 'd>,
+        _d2: Option<impl Peripheral<P = impl InputPin + OutputPin> + 'd>,
+        _d3: Option<impl Peripheral<P = impl InputPin + OutputPin> + 'd>,
+        _d4: Option<impl Peripheral<P = impl InputPin + OutputPin> + 'd>,
+        _d5: Option<impl Peripheral<P = impl InputPin + OutputPin> + 'd>,
+        _d6: Option<impl Peripheral<P = impl InputPin + OutputPin> + 'd>,
+        _d7: Option<impl Peripheral<P = impl InputPin + OutputPin> + 'd>,
+        cd: Option<impl Peripheral<P = impl InputPin> + 'd>,
+        wp: Option<impl Peripheral<P = impl InputPin> + 'd>,
+    ) -> Result<Self, EspError> {
+        let slot_config = sdmmc_slot_config_t {
+            width: width as _,
+            flags: 0,
+            __bindgen_anon_1: sdmmc_slot_config_t__bindgen_ty_1 {
+                cd: cd
+                    .map(|cd| cd.into_ref().deref().pin())
+                    .unwrap_or(SDMMC_SLOT_NO_CD),
+            },
+            __bindgen_anon_2: sdmmc_slot_config_t__bindgen_ty_2 {
+                wp: wp
+                    .map(|wp| wp.into_ref().deref().pin())
+                    .unwrap_or(SDMMC_SLOT_NO_WP),
+            },
+            #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
+            clk: _clk.into_ref().deref().pin(),
+            #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
+            cmd: _cmd.into_ref().deref().pin(),
+            #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
+            d0: _d0.into_ref().deref().pin(),
+            #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
+            d1: _d1.map(|d1| d1.into_ref().deref().pin()).unwrap_or(-1),
+            #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
+            d2: _d2.map(|d2| d2.into_ref().deref().pin()).unwrap_or(-1),
+            #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
+            d3: _d3.map(|d3| d3.into_ref().deref().pin()).unwrap_or(-1),
+            #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
+            d4: _d4.map(|d4| d4.into_ref().deref().pin()).unwrap_or(-1),
+            #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
+            d5: _d5.map(|d5| d5.into_ref().deref().pin()).unwrap_or(-1),
+            #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
+            d6: _d6.map(|d6| d6.into_ref().deref().pin()).unwrap_or(-1),
+            #[cfg(esp_idf_soc_sdmmc_use_gpio_matrix)]
+            d7: _d7.map(|d7| d7.into_ref().deref().pin()).unwrap_or(-1),
+        };
+
+        {
+            let _cs = USED_SLOTS_CS.enter();
+
+            if USED_SLOTS.load(Ordering::SeqCst) == 0 {
+                esp!(unsafe { sdmmc_host_init() })?;
+
+                USED_SLOTS.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        esp!(unsafe { sdmmc_host_init_slot(S::slot() as _, &slot_config) })?;
+
+        Ok(Self {
+            slot: S::slot(),
+            width,
+            _p: PhantomData,
+        })
+    }
+
+    pub(crate) fn slot_no(&self) -> u8 {
+        self.slot
+    }
+
+    pub(crate) fn width(&self) -> u8 {
+        self.width
+    }
+}
+
+impl<'d> Drop for SdMmcHostDriver<'d> {
+    fn drop(&mut self) {
+        let _cs = USED_SLOTS_CS.enter();
+
+        if USED_SLOTS.fetch_sub(1, Ordering::SeqCst) == 1 {
+            esp!(unsafe { sdmmc_host_deinit() }).unwrap();
+        }
+    }
+}
+
+macro_rules! impl_slot {
+    ($instance:ident: $slot:expr) => {
+        crate::impl_peripheral!($instance);
+
+        impl SdMmc for $instance {
+            fn slot() -> u8 {
+                $slot
+            }
+        }
+    };
+}
+
+impl_slot!(SDMMC0: 0);
+impl_slot!(SDMMC1: 1);

--- a/src/sd/mmc.rs
+++ b/src/sd/mmc.rs
@@ -41,7 +41,20 @@ impl<'d> SdMmcHostDriver<'d> {
         wp: Option<impl Peripheral<P = impl InputPin> + 'd>,
     ) -> Result<Self, EspError> {
         Self::new_internal(
-            1, slot, cmd, clk, d0, None, None, None, None, None, None, None, cd, wp,
+            1,
+            slot,
+            cmd,
+            clk,
+            d0,
+            gpio::AnyIOPin::none(),
+            gpio::AnyIOPin::none(),
+            gpio::AnyIOPin::none(),
+            gpio::AnyIOPin::none(),
+            gpio::AnyIOPin::none(),
+            gpio::AnyIOPin::none(),
+            gpio::AnyIOPin::none(),
+            cd,
+            wp,
         )
     }
 
@@ -68,10 +81,10 @@ impl<'d> SdMmcHostDriver<'d> {
             Some(d1),
             Some(d2),
             Some(d3),
-            None,
-            None,
-            None,
-            None,
+            gpio::AnyIOPin::none(),
+            gpio::AnyIOPin::none(),
+            gpio::AnyIOPin::none(),
+            gpio::AnyIOPin::none(),
             cd,
             wp,
         )
@@ -172,10 +185,10 @@ impl<'d> SdMmcHostDriver<'d> {
             Some(d1),
             Some(d2),
             Some(d3),
-            Option::<gpio::AnyIOPin>::None,
-            Option::<gpio::AnyIOPin>::None,
-            Option::<gpio::AnyIOPin>::None,
-            Option::<gpio::AnyIOPin>::None,
+            gpio::AnyIOPin::none(),
+            gpio::AnyIOPin::none(),
+            gpio::AnyIOPin::none(),
+            gpio::AnyIOPin::none(),
             cd,
             wp,
         )

--- a/src/sd/spi.rs
+++ b/src/sd/spi.rs
@@ -1,0 +1,121 @@
+use core::borrow::Borrow;
+use core::marker::PhantomData;
+use core::ops::Deref;
+use core::sync::atomic::{AtomicU8, Ordering};
+
+use crate::gpio::{InputPin, OutputPin};
+use crate::peripheral::Peripheral;
+use crate::spi::SpiDriver;
+use crate::sys::*;
+
+static USED: AtomicU8 = AtomicU8::new(0);
+static USED_CS: crate::task::CriticalSection = crate::task::CriticalSection::new();
+
+/// SPI Host driver for SD cards supporting the SPI protocol.
+pub struct SdSpiHostDriver<'d, T> {
+    _spi_driver: T,
+    handle: sdspi_dev_handle_t,
+    _p: PhantomData<&'d mut ()>,
+}
+
+impl<'d, T> SdSpiHostDriver<'d, T>
+where
+    T: Borrow<SpiDriver<'d>>,
+{
+    /// Create a new SPI host driver for SD cards
+    ///
+    /// # Arguments
+    /// - spi_driver: SPI peripheral driver
+    /// - cs: Chip Select pin (optional)
+    /// - cd: Card Detect pin (optional)
+    /// - wp: Write Protect pin (optional)
+    /// - int: Interrupt pin (optional)
+    /// - wp_active_high: Write Protect active when high (optional, default = `false`)
+    pub fn new(
+        spi_driver: T,
+        cs: Option<impl Peripheral<P = impl OutputPin> + 'd>,
+        cd: Option<impl Peripheral<P = impl InputPin> + 'd>,
+        wp: Option<impl Peripheral<P = impl InputPin> + 'd>,
+        int: Option<impl Peripheral<P = impl InputPin> + 'd>,
+        #[cfg(not(any(
+            esp_idf_version_major = "4",
+            all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+            all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+        )))] // For ESP-IDF v5.2 and later
+        wp_active_high: Option<bool>,
+    ) -> Result<Self, EspError>
+    where
+        T: Borrow<SpiDriver<'d>>,
+    {
+        let dev_config = sdspi_device_config_t {
+            host_id: spi_driver.borrow().host(),
+            gpio_cs: cs.map(|cd| cd.into_ref().deref().pin()).unwrap_or(-1),
+            gpio_cd: cd.map(|cd| cd.into_ref().deref().pin()).unwrap_or(-1),
+            gpio_wp: wp.map(|wp| wp.into_ref().deref().pin()).unwrap_or(-1),
+            gpio_int: int.map(|int| int.into_ref().deref().pin()).unwrap_or(-1),
+            #[cfg(not(any(
+                esp_idf_version_major = "4",
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
+                all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
+            )))] // For ESP-IDF v5.2 and later
+            gpio_wp_polarity: wp_active_high.unwrap_or(false), // `false` = active when low
+        };
+
+        {
+            let _cs = USED_CS.enter();
+
+            if USED.load(Ordering::SeqCst) == 0 {
+                esp!(unsafe { sdspi_host_init() })?;
+
+                USED.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let mut handle = 0;
+
+        esp!(unsafe { sdspi_host_init_device(&dev_config, &mut handle) })?;
+
+        Ok(Self {
+            _spi_driver: spi_driver,
+            handle,
+            _p: PhantomData,
+        })
+    }
+
+    pub fn handle(&self) -> sdspi_dev_handle_t {
+        self.handle
+    }
+
+    // TODO: Figure out if any of the below is necessary
+    
+    // // TODO: Clock
+    // pub fn set_clock(&mut self, clock: u32) -> Result<(), EspError> {
+    //     esp!(unsafe { sdspi_host_set_card_clk(self.handle, clock) })
+    // }
+
+    // pub fn enable_interrupt(&mut self) -> Result<(), EspError> {
+    //     esp!(unsafe { sdspi_host_io_int_enable(self.get_host() as i32) })
+    // }
+
+    // pub fn wait_interrupt(&mut self, timeout: u32) -> Result<(), EspError> {
+    //     esp!(unsafe { sdspi_host_io_int_wait(self.get_host() as i32, timeout) })
+    // }
+
+    // pub(crate) fn get_device_configuration(&self) -> &sdspi_device_config_t {
+    //     &self.configuration
+    // }
+}
+
+impl<'d, T> Drop for SdSpiHostDriver<'d, T> {
+    fn drop(&mut self) {
+        esp!(unsafe { sdspi_host_remove_device(self.handle) }).unwrap();
+
+        {
+            let _cs = USED_CS.enter();
+
+            if USED.fetch_sub(1, Ordering::SeqCst) == 1 {
+                esp!(unsafe { sdspi_host_deinit() }).unwrap();
+            }
+        }
+    }
+}

--- a/src/sd/spi.rs
+++ b/src/sd/spi.rs
@@ -85,25 +85,6 @@ where
     pub fn handle(&self) -> sdspi_dev_handle_t {
         self.handle
     }
-
-    // TODO: Figure out if any of the below is necessary
-
-    // // TODO: Clock
-    // pub fn set_clock(&mut self, clock: u32) -> Result<(), EspError> {
-    //     esp!(unsafe { sdspi_host_set_card_clk(self.handle, clock) })
-    // }
-
-    // pub fn enable_interrupt(&mut self) -> Result<(), EspError> {
-    //     esp!(unsafe { sdspi_host_io_int_enable(self.get_host() as i32) })
-    // }
-
-    // pub fn wait_interrupt(&mut self, timeout: u32) -> Result<(), EspError> {
-    //     esp!(unsafe { sdspi_host_io_int_wait(self.get_host() as i32, timeout) })
-    // }
-
-    // pub(crate) fn get_device_configuration(&self) -> &sdspi_device_config_t {
-    //     &self.configuration
-    // }
 }
 
 impl<'d, T> Drop for SdSpiHostDriver<'d, T> {

--- a/src/sd/spi.rs
+++ b/src/sd/spi.rs
@@ -87,7 +87,7 @@ where
     }
 
     // TODO: Figure out if any of the below is necessary
-    
+
     // // TODO: Clock
     // pub fn set_clock(&mut self, clock: u32) -> Result<(), EspError> {
     //     esp!(unsafe { sdspi_host_set_card_clk(self.handle, clock) })


### PR DESCRIPTION
(Related to https://github.com/esp-rs/esp-idf-svc/issues/439 and https://github.com/esp-rs/esp-idf-svc/pull/448 and supersedes https://github.com/esp-rs/esp-idf-svc/pull/448 .)

Sibling PR for `esp-idf-svc`: https://github.com/esp-rs/esp-idf-svc/pull/454

#### Overview

This PR introduces safe SD-Card drivers wrappers which closely follows the ESP-IDF drivers. Namely:
- High-level SD-Card driver: `SdCardDriver` which wraps a low-level SD-Card Host driver (see below) 
  - Allows sector-level SD-Card access (i.e. read/write/erase sectors), as well as reads and writes with arbitrary byte lengths. 
  - Currently, only the safe instantiation / drop of the driver is implemented. For sector access, one needs to use the raw `esp-idf-sys` API with the driver
- Low level SD-Card Host drivers:
  - SD-SPI Host driver: `SdSpiHostDriver`
  - SD-MMC Host driver (for MCUs which do have an SD-MMC peripheral, namely esp32, esp32s3 and esp32p4): `SdMmcHostDriver`
  - The Host drivers are not really useful by themselves, yet they have public APIs for instantiation and dropping. Still, they are just an implementation detail of the SD-Card driver of sorts

#### But why?

The existing "fatfs" support in `esp-idf-svc` which was introduced with the last non-patch release has the following restrictions:
* It models the "toy" / "convenience" API of VFS, namely `esp_vfs_fat_sdmmc_mount` / `esp_vfs_fat_sdspi_mount` whereas ESP IDF explicitly advises this API _not_ to be used for production scenarios
* More importantly, the current "fatfs" support offers limited flexibility:
  * Can't mount a "fatfs" on the internal flash partition; only SD-Cards are supported
  * Can't format a FATFS partition/sdcard explicitly; only if the VFS mount fails, as a side effect
  * Can't operate on a "fatfs" via its native FATFS API but only via the VFS (= Rust) API (might be useful in future)
  * Can't operate on an SD-Card using its sectors API (might be even more useful in future)
* The current "fatfs" API is a bit weird, as it essentially models a bunch of configurations for the `esp_vfs_fat_sdmmc_mount` mega-call. Nothing else in the hal and svc crates looks like this
* The currentl "fatfs" API **does not model SDMMC slots correctly**. Slots are essentially the two legs of the SDMMC **peripheral**. As such, they should be modeled as peripherals, rather than as a "freestanding" `enum` as it is now, thus not allowing the user to instantiate a second time the same slot with the new `SdMmcHostDriver`
* There is also another logical error w.r.t. slots: the current "fatfs" code wrongly assumes that on esp32s3 and esp32p4 **slots do not exist**. But they do! The only difference between the esp32 slots and those of esp32s3 and esp32p4 is that:
  * The esp32 slots are hard-coded to **specific** pins as they always operate via the IO MUX
  * In esp32s3 and esp32s4 this restriction is lifted, and the slots operate via the GPIO matrix. But slots are still there!