### PR TITLE
Add precision on "Any pin can be used for tx and rx"

### DIFF
--- a/src/uart.rs
+++ b/src/uart.rs
@@ -3,7 +3,12 @@
 //! Controls UART peripherals (UART0, UART1, UART2).
 //! Notice that UART0 is typically already used for loading firmware and logging.
 //! Therefore use UART1 and UART2 in your application.
+//!
 //! Any pin can be used for `rx` and `tx`.
+//! Indeed, all pins of an ESP are equal when it comes to UART and can be used
+//! for it equivalently using ESP-IDF.
+//! Having to deal with predefined UART configurations is just a limitation of
+//! the Arduino framework.
 //!
 //! # Example
 //!


### PR DESCRIPTION
When I started looking at the documentation of the UART module, having used the Arduino framework, I was confused as to why any pin can be used for TX and RX. I wondered if they were all actually equivalent or if there was some kind of software serial fallback mechanism under the hood. I figured out later on the official ESP-IDF doc what I wrote in the commit (please review it thoroughly I have actually no idea what I’m talking about). I think such a notice can save quite some time for Arduino newcomers.