### PR TITLE
Bugfix: drop calibration handle on driver drop; more control on the r…

### DIFF
--- a/examples/adc_oneshot.rs
+++ b/examples/adc_oneshot.rs
@@ -23,7 +23,6 @@ fn main() -> anyhow::Result<()> {
     // for this example we use the attenuation of 11db which sets the input voltage range to around 0-3.6V
     let config = AdcChannelConfig {
         attenuation: DB_11,
-        calibration: true,
         ..Default::default()
     };
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -731,7 +731,7 @@ pub mod oneshot {
                     any(esp32, esp32c2, esp32s2)
                 ))]
                 Self::LineFittingCalibration(handle) => {
-                    esp!(unsafe { esp_idf_sys::adc_cali_delete_scheme_curve_fitting(*handle) })
+                    esp!(unsafe { esp_idf_sys::adc_cali_delete_scheme_line_fitting(*handle) })
                         .unwrap()
                 }
             }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -594,6 +594,7 @@ pub mod oneshot {
     }
 
     impl Converter {
+        #[allow(unused_variables)]
         fn create(
             unit_id: u8,
             chan: adc_channel_t,

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -91,7 +91,7 @@ mod oneshot_legacy {
 
     use crate::peripheral::{Peripheral, PeripheralRef};
 
-    use super::{to_nb_err, Adc};
+    use super::{to_nb_err, Adc, DirectConverter};
 
     pub type AdcConfig = config::Config;
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -493,7 +493,6 @@ impl DirectConverter {
 ///     /// for this example we use the attenuation of 11db which sets the input voltage range to around 0-3.6V
 ///     let config = AdcChannelConfig {
 ///         attenuation: DB_11,
-///         calibration: true,
 ///         ..Default::default()
 ///     };
 ///     let mut adc_pin = AdcChannelDriver::new(&adc, peripherals.pins.gpio2, &config)?;
@@ -571,6 +570,7 @@ pub mod oneshot {
         }
     }
 
+    /// Converts a raw reading to mV with or without calibration
     enum Converter {
         NoCalibration(adc_atten_t),
         #[cfg(all(

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -794,7 +794,7 @@ pub mod oneshot {
         #[inline(always)]
         pub fn read(&mut self) -> Result<u16, EspError> {
             let raw = self.read_raw()?;
-            self.raw_to_cal(raw)
+            self.raw_to_mv(raw)
         }
 
         #[inline(always)]
@@ -804,7 +804,7 @@ pub mod oneshot {
         }
 
         #[inline(always)]
-        pub fn raw_to_cal(&self, raw: u16) -> Result<u16, EspError> {
+        pub fn raw_to_mv(&self, raw: u16) -> Result<u16, EspError> {
             self.converter.raw_to_mv(raw)
         }
     }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -768,7 +768,7 @@ pub mod oneshot {
                 bitwidth: config.resolution.into(),
             };
 
-            let calibration = Converter::create(
+            let converter = Converter::create(
                 T::Adc::unit() as u8,
                 pin.adc_channel(),
                 config.attenuation,
@@ -787,7 +787,7 @@ pub mod oneshot {
             Ok(Self {
                 adc,
                 _pin: pin,
-                converter: calibration,
+                converter,
             })
         }
 


### PR DESCRIPTION
* Turns out, the "new" oneshot ADC driver does not deallocate the `adc_cali_handle` on drop. 
* I also noticed that the `calibration` bool from the `Config` does not have any effect. The driver always uses calibration, even if `calibration` is set to `false` (which it is by default).

The fix also introduces a breaking change, in that the user is now capable of selecting the calibration scheme when configuring the driver (or no calibration), with:
* `Calibration::None`
* `Calibration::CurveFitting`
* `Calibration::LineFitting`