### PR TITLE
Add dual and quad SPI support

### DIFF
--- a/examples/spi_loopback.rs
+++ b/examples/spi_loopback.rs
@@ -12,7 +12,6 @@
 //! This example transfers data via SPI.
 //! Connect SDI and SDO pins to see the outgoing data is read as incoming data.
 
-use embedded_hal::spi::Operation;
 use esp_idf_hal::delay::FreeRtos;
 use esp_idf_hal::peripherals::Peripherals;
 use esp_idf_hal::prelude::*;

--- a/examples/spi_loopback_async.rs
+++ b/examples/spi_loopback_async.rs
@@ -12,7 +12,6 @@
 //! This example transfers data via SPI.
 //! Connect SDI and SDO pins to see the outgoing data is read as incoming data.
 
-use embedded_hal::spi::Operation;
 use esp_idf_hal::peripherals::Peripherals;
 use esp_idf_hal::prelude::*;
 use esp_idf_hal::spi::*;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1751,10 +1751,10 @@ fn spi_read_transactions(
         spi_create_transaction(
             chunk.as_mut_ptr(),
             core::ptr::null(),
-            if duplex == Duplex::Half3Wire {
-                0
-            } else {
+            if duplex == Duplex::Full {
                 chunk.len()
+            } else {
+                0
             },
             chunk.len(),
         )

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -198,6 +198,16 @@ pub mod config {
         }
     }
 
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+    pub enum LineWidth {
+        /// 1-bit, 2 wire duplex or 1 wire half-duplex
+        Single,
+        /// 2-bit, 2 wire half-duplex
+        Dual,
+        /// 4-bit, 4 wire half-duplex
+        Quad,
+    }
+
     /// SPI Driver configuration
     #[derive(Debug, Clone)]
     pub struct DriverConfig {


### PR DESCRIPTION
Fixes #49

This set of commits introduces a few changes, in order to support dual and quad SPI:

* `SpiDriver::new_dual` and `SpiDriver::new_quad` constructors, to allow creating a SpiDriver while specifying additional pins and modes. 
* `LineWidth` enum
* And a `TransactionExt` struct (and functions that use it), which is an analog of the `spi_transaction_ext_t` in esp-idf.

By adding `TransactionExt`, this also enables hardware support for command, address, and dummy phases.

---

Overall, this is a little bit of a weird addition. I don't think it fits in *super* well with the existing API, but I couldn't think of a better way to do it.

In particular, some things that wouldn't work:
* Adding `LineWidth` to `Operation`, to allow using the same methods: this won't work because `Operation` comes from `embedded_hal`, and can't be modified
* Adding line width to `SpiConfig`: this seemed like a nice solution, but the problem is that multi-line spi devices generally don't do *all* their communications with quad spi -- often they have a 1-bit wide command phase, and then a 1 or 4-bit wide address, and then a 4-bit wide data phase. If this is just set on `SpiConfig`, then it wouldn't be possible to have narrower and wider phases. 

Internally, everything had to be changed from spi_transaction_t to spi_transaction_ext_t -- this allows specifying the width of the command/address/dummy phases, which is needed because the older methods just use the data phase, and the newer methods (may) use those other phases. 

The wider widths can only be used in half-duplex mode. With the current SPI api, there isn't a good way to encode this constraint with types (like in esp_hal: https://docs.esp-rs.org/esp-hal/esp-hal/0.20.0/esp32s3/esp_hal/spi/master/trait.HalfDuplexReadWrite.html). However, esp-idf checks this, and logs an error and returns an error code.