### PR TITLE
Fix esp_reset_reason_t constant names

### DIFF
--- a/src/reset.rs
+++ b/src/reset.rs
@@ -124,7 +124,7 @@ impl From<esp_reset_reason_t> for ResetReason {
                 esp_idf_version_full = "5.2.0",
                 esp_idf_version_full = "5.2.1",
             )))]
-            esp_reset_reason_t_ESP_RST_PG => Self::PowerGlitch,
+            esp_reset_reason_t_ESP_RST_PWR_GLITCH => Self::PowerGlitch,
             #[cfg(not(any(
                 esp_idf_version_major = "4",
                 all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),
@@ -132,7 +132,7 @@ impl From<esp_reset_reason_t> for ResetReason {
                 esp_idf_version_full = "5.2.0",
                 esp_idf_version_full = "5.2.1",
             )))]
-            esp_reset_reason_t_ESP_RST_CPU => Self::CPULockup,
+            esp_reset_reason_t_ESP_RST_CPU_LOCKUP => Self::CPULockup,
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
The esp_reset_reason_t ESP_RST_PG and ESP_RST_CPU constant names don't seem to exist. Instead, the actual names (added in esp-idf 5.2.2) are ESP_RST_PWR_GLITCH and ESP_RST_CPU_LOCKUP.

The incorrect names caused the second-to-last match arm to be interpreted as a binding name (that is, a catch-all), causing incorrect behavior and build warnings when using esp-idf 5.2.2 and up.

---

See https://github.com/espressif/esp-idf/blame/v5.2.2/components/esp_system/include/esp_system.h#L39-L40

These were added in https://github.com/espressif/esp-idf/commit/e930ff0b1f527591b16e8f94f62ab2027b1c40fb -- I'm not sure where the incorrect names (used in #444) came from.