### PR TITLE
Typo fix in task docs

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -38,7 +38,7 @@ const NO_AFFINITY: core::ffi::c_uint = tskNO_AFFINITY;
 ///
 /// # Safety
 ///
-/// Only marked as unsafe fo symmetry with `destroy` and to discourage users from leaning on it in favor of `std::thread`.
+/// Only marked as unsafe for symmetry with `destroy` and to discourage users from leaning on it in favor of `std::thread`.
 /// Otherwise, this function is actually safe.
 pub unsafe fn create(
     task_handler: extern "C" fn(*mut core::ffi::c_void),


### PR DESCRIPTION
- small typo fix "fo" -> "for" in task docs