### PR TITLE
Fix RGB to u32 conversion order in rmt_neopixel example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fix RGB to u32 conversion order in rmt_neopixel example (#505)
+
 ## [0.45.0] - 2025-01-02
 
 ### Deprecated

--- a/examples/rmt_neopixel.rs
+++ b/examples/rmt_neopixel.rs
@@ -121,7 +121,7 @@ mod example {
         /// 7      0 7      0 7      0
         /// 00000010 00000001 00000100
         fn from(rgb: Rgb) -> Self {
-            ((rgb.r as u32) << 16) | ((rgb.g as u32) << 8) | rgb.b as u32
+            ((rgb.g as u32) << 16) | ((rgb.r as u32) << 8) | rgb.b as u32
         }
     }
 }


### PR DESCRIPTION
The current `From<Rgb> for u32` implementation in NeoPixel example appears to be incorrect. 
According to the [datasheet](https://cdn-shop.adafruit.com/datasheets/WS2812.pdf), data should be sent in GRB order. This PR changes the `From<Rgb>` implementation to match the datasheet's requirement by swapping the positions of red and 
green components in the bit shifting operation.

