### PR TITLE
Fix #507 - add missing sdmmc_host_get_dma_info for sdcard driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix RGB to u32 conversion order in rmt_neopixel example (#505)
+- Fix missing sdmmc_host_get_dma_info for sdcard driver bug (#507)
 
 ## [0.45.0] - 2025-01-02
 

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -387,7 +387,7 @@ mod sdcard {
                     all(esp_idf_version_major = "5", esp_idf_version_minor = "1"),
                     all(esp_idf_version_major = "5", esp_idf_version_minor = "2"),
                 )))]   // For ESP-IDF v5.3 and later
-                get_dma_info: None,
+                get_dma_info: Some(sdmmc_host_get_dma_info),
                 #[cfg(not(any(
                     esp_idf_version_major = "4",
                     all(esp_idf_version_major = "5", esp_idf_version_minor = "0"),


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.

### Pull Request Details 📖

Fix #507 by adding the missing `sdmmc_host_get_dma_info` function pointer for the SD card host driver

#### Description

The `get_dma_info` function pointer here:

https://github.com/esp-rs/esp-idf-hal/blob/8a11ef463ea78920e89755525d1cb995f13b1cec/src/sd.rs#L384-L390

supposes to be pointing to `sdmmc_host_get_dma_info` based on what I saw from the [SDMMC_HOST_DEFAULT](https://github.com/espressif/esp-idf/blob/b5ac4fbdf9e9fb320bb0a98ee4fbaa18f8566f37/components/esp_driver_sdmmc/include/driver/sdmmc_default_configs.h#L52) macro. Without this func pointer, the first time calling it will crash due to calling a null pointer from here:

https://github.com/espressif/esp-idf/blob/d7d3eb3f0a99f069a7814b3c0824626383e4a511/components/sdmmc/sdmmc_sd.c#L95

#### Testing

Adding patch pointing hal repo to my PR this problem is gone:

```
[patch.crates-io]
esp-idf-hal = { git = "https://github.com/LaunchPlatform/esp-idf-hal", rev = "ec432eae61fdbeecaaf05a7bd33b8ffa738911ab" }
```

output:

```
I (416) sleep: Configure to isolate all GPIO pins in sleep state
I (423) sleep: Enable automatic switching of GPIO sleep configuration
I (431) main_task: Started on CPU0
I (441) main_task: Calling app_main()
I (441) gpio: GPIO[36]| InputEn: 0| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0
I (451) gpio: GPIO[35]| InputEn: 0| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0 
I (461) gpio: GPIO[37]| InputEn: 0| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0
I (531) esp_idf_svc_ws_client_cross_thread_bug: File File { fd: 9 } created
I (531) esp_idf_svc_ws_client_cross_thread_bug: File File { fd: 9 } written with [72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 33]
I (541) esp_idf_svc_ws_client_cross_thread_bug: File File { fd: 9 } seeked
I (551) esp_idf_svc_ws_client_cross_thread_bug: File File { fd: 9 } opened
I (561) esp_idf_svc_ws_client_cross_thread_bug: File File { fd: 9 } read: Hello, world!
I (561) esp_idf_svc_ws_client_cross_thread_bug: Entry: "DCIM"
I (571) esp_idf_svc_ws_client_cross_thread_bug: Entry: "FOO.TXT"
I (571) esp_idf_svc_ws_client_cross_thread_bug: Entry: "SYSTEM~1"
I (581) esp_idf_svc_ws_client_cross_thread_bug: Entry: "TEST.TXT"

```

you can also see the branch I created in the reproducing repo:

https://github.com/LaunchPlatform/esp-idf-hal-sd-get-info-dma-bug/tree/with-fix