### PR TITLE
Replace Arc with Rc in ledc_threads example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix the SDMMC driver for ESP-IDF V5.5+
-- Replace Arc with Rc in ledc_threads example
+- Replace Arc with Rc in ledc_threads example (#514)
 
 ## [0.45.2] - 2025-01-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix the SDMMC driver for ESP-IDF V5.5+
+- Replace Arc with Rc in ledc_threads example
 
 ## [0.45.2] - 2025-01-15
 

--- a/examples/ledc_threads.rs
+++ b/examples/ledc_threads.rs
@@ -1,4 +1,5 @@
-use std::{sync::Arc, time::Duration};
+use std::rc::Rc;
+use std::time::Duration;
 
 use embedded_hal_0_2::PwmPin;
 
@@ -15,7 +16,7 @@ fn main() -> anyhow::Result<()> {
 
     let peripherals = Peripherals::take()?;
     let config = config::TimerConfig::new().frequency(25.kHz().into());
-    let timer = Arc::new(LedcTimerDriver::new(peripherals.ledc.timer0, &config)?);
+    let timer = Rc::new(LedcTimerDriver::new(peripherals.ledc.timer0, &config)?);
     let channel0 = LedcDriver::new(
         peripherals.ledc.channel0,
         timer.clone(),


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
This pull request replaces the use of `Arc` with `Rc` for sharing the `LedcTimerDriver` instance among multiple `LedcDriver` instances in the `ledc_threads` example. This change addresses a clippy warning (usage of an `Arc` that is not `Send` and `Sync`).

#### Testing
The updated code compiles without issues and runs successfully on a device.