### PR TITLE
fix: update docs for task::notification::Notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix the SDMMC driver for ESP-IDF V5.5+
+- Fix outdated task docs
 
 ## [0.45.2] - 2025-01-15
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -935,13 +935,11 @@ pub mod notification {
     impl Notifier {
         /// # Safety
         ///
-        /// This method is unsafe because it is possible to call `core::mem::forget` on the Monitor instance
-        /// that produced this notifier.
+        /// Care should be taken to ensure that `Notifier` does not outlive the task
+        /// in which the `Notification` that produced it was created.
         ///
-        /// If that happens, the `Drop` dtor of `Monitor` will NOT be called, which - in turn - means that the
-        /// `Arc` holding the task reference will stick around even when the actual task where the `Monitor` instance was
-        /// created no longer exists. Which - in turn - would mean that the method will be trying to notify a task
-        /// which does no longer exist, which would lead to UB and specifically - to memory corruption.
+        /// If that happens, a dangling pointer instead of proper task handle will be passed to `task::notify`,
+        /// which will result in memory corruption.
         pub unsafe fn notify(&self, notification: NonZeroU32) -> (bool, bool) {
             let freertos_task = self.0.load(Ordering::SeqCst);
 
@@ -954,13 +952,11 @@ pub mod notification {
 
         /// # Safety
         ///
-        /// This method is unsafe because it is possible to call `core::mem::forget` on the Monitor instance
-        /// that produced this notifier.
+        /// Care should be taken to ensure that `Notifier` does not outlive the task
+        /// in which the `Notification` that produced it was created.
         ///
-        /// If that happens, the `Drop` dtor of `Monitor` will NOT be called, which - in turn - means that the
-        /// `Arc` holding the task reference will stick around even when the actual task where the `Monitor` instance was
-        /// created no longer exists. Which - in turn - would mean that the method will be trying to notify a task
-        /// which does no longer exist, which would lead to UB and specifically - to memory corruption.
+        /// If that happens, a dangling pointer instead of proper task handle will be passed to `task::notify_and_yield`,
+        /// which will result in memory corruption.
         pub unsafe fn notify_and_yield(&self, notification: NonZeroU32) -> bool {
             let freertos_task = self.0.load(Ordering::SeqCst);
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
The docs for task::notification::Notifier methods were outdated:
- referenced `Monitor` struct, that was renamed to `Notification`,
- referenced a `Drop` trait, that is not implemented anymore,
- described implementation details that are no longer accurate.

#### Testing
N/A