### PR TITLE
ledc: add support for fading leds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `Send` for `AsyncCanDriver`
+- `fade_with_time`, `fade_with_step` for `LedcDriver`
 
 ### Fixed
 - Fix the SDMMC driver for ESP-IDF V5.5+

--- a/examples/ledc_fade.rs
+++ b/examples/ledc_fade.rs
@@ -1,0 +1,39 @@
+use esp_idf_hal::delay::FreeRtos;
+use esp_idf_hal::ledc::{config::TimerConfig, LedcDriver, LedcTimerDriver};
+use esp_idf_hal::peripherals::Peripherals;
+use esp_idf_hal::prelude::*;
+use std::time::Duration;
+
+fn main() -> anyhow::Result<()> {
+    esp_idf_hal::sys::link_patches();
+
+    let peripherals = Peripherals::take()?;
+
+    let timer_driver = LedcTimerDriver::new(
+        peripherals.ledc.timer0,
+        &TimerConfig::default().frequency(25.kHz().into()),
+    )?;
+
+    let mut ledc_driver = LedcDriver::new(
+        peripherals.ledc.channel0,
+        timer_driver,
+        peripherals.pins.gpio7,
+    )?;
+
+    for _ in 0..2 {
+        // Fade up over 2 seconds
+        ledc_driver.fade_with_time(
+            ledc_driver.get_max_duty(),
+            Duration::from_secs(2).as_millis() as i32,
+            true,
+        )?;
+
+        // Fade down over 2 seconds
+        ledc_driver.fade_with_time(0, Duration::from_secs(2).as_millis() as i32, true)?;
+    }
+
+    ledc_driver.set_duty(ledc_driver.get_max_duty() / 10)?;
+    FreeRtos::delay_ms(10000);
+
+    Ok(())
+}


### PR DESCRIPTION
### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [ ] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Added support for fading leds via two new methods on `LedcDriver`: `fade_with_time` and `fade_with_step`.

I have not yet implemented support for registering a callback to be called upon fade completion, but will look into contributing that in a future PR.

Implements #518

#### Testing
I added `ledc_fade.rs` to the examples, which shows how to use the new functionality. I have run this successfully on an esp32-c3 wroom board with external leds.