### PR TITLE
feat: add `DB_12` adc attenuation and deprecate `DB_11` for ESP-IDF V5.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+- `DB_11` ADC attenuation in favor of `DB_12` for ESP-IDF V5.0+
+
 ### Added
 - `Send` for `AsyncCanDriver`
+- `DB_12` ADC attenuation
 
 ### Fixed
 - Fix the SDMMC driver for ESP-IDF V5.5+

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -1,7 +1,7 @@
 //! ADC example, reading a value form a pin and printing it on the terminal
 //!
 
-use esp_idf_sys::{self as _}; // If using the `binstart` feature of `esp-idf-sys`, always keep this module imported
+use esp_idf_sys::{self as _, adc_atten_t}; // If using the `binstart` feature of `esp-idf-sys`, always keep this module imported
 
 use std::thread;
 use std::time::Duration;
@@ -20,14 +20,19 @@ fn main() -> anyhow::Result<()> {
     #[cfg(esp32)]
     let mut adc = AdcDriver::new(peripherals.adc2, &Config::new().calibration(true))?;
 
+    #[cfg(esp_idf_version_major = "4")]
+    const ATTENUATION: adc_atten_t = attenuation::DB_11;
+    #[cfg(not(esp_idf_version_major = "4"))]
+    const ATTENUATION: adc_atten_t = attenuation::DB_12;
+
     // configuring pin to analog read, you can regulate the adc input voltage range depending on your need
     // for this example we use the attenuation of 11db which sets the input voltage range to around 0-3.6V
     #[cfg(not(esp32))]
-    let mut adc_pin: esp_idf_hal::adc::AdcChannelDriver<{ attenuation::DB_12 }, _> =
+    let mut adc_pin: esp_idf_hal::adc::AdcChannelDriver<{ ATTENUATION }, _> =
         AdcChannelDriver::new(peripherals.pins.gpio4)?;
 
     #[cfg(esp32)]
-    let mut adc_pin: esp_idf_hal::adc::AdcChannelDriver<{ attenuation::DB_12 }, _> =
+    let mut adc_pin: esp_idf_hal::adc::AdcChannelDriver<{ ATTENUATION }, _> =
         AdcChannelDriver::new(peripherals.pins.gpio12)?;
 
     loop {

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -23,11 +23,11 @@ fn main() -> anyhow::Result<()> {
     // configuring pin to analog read, you can regulate the adc input voltage range depending on your need
     // for this example we use the attenuation of 11db which sets the input voltage range to around 0-3.6V
     #[cfg(not(esp32))]
-    let mut adc_pin: esp_idf_hal::adc::AdcChannelDriver<{ attenuation::DB_11 }, _> =
+    let mut adc_pin: esp_idf_hal::adc::AdcChannelDriver<{ attenuation::DB_12 }, _> =
         AdcChannelDriver::new(peripherals.pins.gpio4)?;
 
     #[cfg(esp32)]
-    let mut adc_pin: esp_idf_hal::adc::AdcChannelDriver<{ attenuation::DB_11 }, _> =
+    let mut adc_pin: esp_idf_hal::adc::AdcChannelDriver<{ attenuation::DB_12 }, _> =
         AdcChannelDriver::new(peripherals.pins.gpio12)?;
 
     loop {

--- a/examples/adc_oneshot.rs
+++ b/examples/adc_oneshot.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 #[cfg(not(any(feature = "adc-oneshot-legacy", esp_idf_version_major = "4")))]
 fn main() -> anyhow::Result<()> {
-    use esp_idf_hal::adc::attenuation::DB_11;
+    use esp_idf_hal::adc::attenuation::DB_12;
     use esp_idf_hal::adc::oneshot::config::AdcChannelConfig;
     use esp_idf_hal::adc::oneshot::*;
     use esp_idf_hal::peripherals::Peripherals;
@@ -22,7 +22,7 @@ fn main() -> anyhow::Result<()> {
     // configuring pin to analog read, you can regulate the adc input voltage range depending on your need
     // for this example we use the attenuation of 11db which sets the input voltage range to around 0-3.6V
     let config = AdcChannelConfig {
-        attenuation: DB_11,
+        attenuation: DB_12,
         ..Default::default()
     };
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -7,6 +7,7 @@ use esp_idf_sys::*;
     not(esp32c2),
     esp_idf_comp_esp_adc_enabled
 ))]
+#[allow(deprecated)]
 pub use continuous::{
     config as cont_config, config::Config as AdcContConfig, AdcChannels, AdcChannelsArray,
     AdcDriver as AdcContDriver, AdcMeasurement, Atten11dB, Atten12dB, Atten2p5dB, Atten6dB,
@@ -1006,6 +1007,7 @@ pub mod continuous {
         }
     }
 
+    #[allow(deprecated)]
     impl<T> Attenuated<{ attenuation::DB_11 }, T> {
         #[cfg_attr(
             not(esp_idf_version_major = "4"),
@@ -1036,6 +1038,7 @@ pub mod continuous {
         not(esp_idf_version_major = "4"),
         deprecated(since = "0.45.3", note = "Use `Atten12dB` instead")
     )]
+    #[allow(deprecated)]
     pub type Atten11dB<T> = Attenuated<{ attenuation::DB_11 }, T>;
     #[cfg(not(esp_idf_version_major = "4"))]
     pub type Atten12dB<T> = Attenuated<{ attenuation::DB_12 }, T>;

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -9,8 +9,8 @@ use esp_idf_sys::*;
 ))]
 pub use continuous::{
     config as cont_config, config::Config as AdcContConfig, AdcChannels, AdcChannelsArray,
-    AdcDriver as AdcContDriver, AdcMeasurement, Atten11dB, Atten2p5dB, Atten6dB, AttenNone,
-    Attenuated, ChainedAdcChannels, EmptyAdcChannels,
+    AdcDriver as AdcContDriver, AdcMeasurement, Atten11dB, Atten12dB, Atten2p5dB, Atten6dB,
+    AttenNone, Attenuated, ChainedAdcChannels, EmptyAdcChannels,
 };
 
 #[cfg(any(feature = "adc-oneshot-legacy", esp_idf_version_major = "4"))]
@@ -22,6 +22,8 @@ pub trait Adc: Send {
 
 // NOTE: Will be changed to an enum once C-style enums are usable as const generics
 pub mod attenuation {
+    #[cfg(not(esp_idf_version_major = "4"))]
+    pub use esp_idf_sys::adc_atten_t_ADC_ATTEN_DB_12;
     pub use esp_idf_sys::{
         adc_atten_t, adc_atten_t_ADC_ATTEN_DB_0, adc_atten_t_ADC_ATTEN_DB_11,
         adc_atten_t_ADC_ATTEN_DB_2_5, adc_atten_t_ADC_ATTEN_DB_6,
@@ -30,7 +32,13 @@ pub mod attenuation {
     pub const NONE: adc_atten_t = adc_atten_t_ADC_ATTEN_DB_0;
     pub const DB_2_5: adc_atten_t = adc_atten_t_ADC_ATTEN_DB_2_5;
     pub const DB_6: adc_atten_t = adc_atten_t_ADC_ATTEN_DB_6;
+    #[cfg_attr(
+        not(esp_idf_version_major = "4"),
+        deprecated(since = "0.45.3", note = "Use `DB_12` instead")
+    )]
     pub const DB_11: adc_atten_t = adc_atten_t_ADC_ATTEN_DB_11;
+    #[cfg(not(esp_idf_version_major = "4"))]
+    pub const DB_12: adc_atten_t = adc_atten_t_ADC_ATTEN_DB_12;
 }
 
 /// The sampling/readout resolution of the ADC
@@ -448,6 +456,9 @@ impl DirectConverter {
             adc_atten_t_ADC_ATTEN_DB_0 => 950,
             adc_atten_t_ADC_ATTEN_DB_2_5 => 1250,
             adc_atten_t_ADC_ATTEN_DB_6 => 1750,
+            #[cfg(not(esp_idf_version_major = "4"))]
+            adc_atten_t_ADC_ATTEN_DB_12 => 2450,
+            #[cfg(esp_idf_version_major = "4")]
             adc_atten_t_ADC_ATTEN_DB_11 => 2450,
             other => panic!("Unknown attenuation: {}", other),
         };
@@ -457,6 +468,9 @@ impl DirectConverter {
             adc_atten_t_ADC_ATTEN_DB_0 => 750,
             adc_atten_t_ADC_ATTEN_DB_2_5 => 1050,
             adc_atten_t_ADC_ATTEN_DB_6 => 1300,
+            #[cfg(not(esp_idf_version_major = "4"))]
+            adc_atten_t_ADC_ATTEN_DB_12 => 2500,
+            #[cfg(esp_idf_version_major = "4")]
             adc_atten_t_ADC_ATTEN_DB_11 => 2500,
             other => panic!("Unknown attenuation: {}", other),
         };
@@ -466,6 +480,9 @@ impl DirectConverter {
             adc_atten_t_ADC_ATTEN_DB_0 => 950,
             adc_atten_t_ADC_ATTEN_DB_2_5 => 1250,
             adc_atten_t_ADC_ATTEN_DB_6 => 1750,
+            #[cfg(not(esp_idf_version_major = "4"))]
+            adc_atten_t_ADC_ATTEN_DB_12 => 3100,
+            #[cfg(esp_idf_version_major = "4")]
             adc_atten_t_ADC_ATTEN_DB_11 => 3100,
             other => panic!("Unknown attenuation: {}", other),
         };
@@ -481,7 +498,7 @@ impl DirectConverter {
 /// use std::time::Duration;
 ///
 /// fn main() -> anyhow::Result<()> {
-///     use esp_idf_hal::adc::attenuation::DB_11;
+///     use esp_idf_hal::adc::attenuation::DB_12;
 ///     use esp_idf_hal::adc::oneshot::config::AdcChannelConfig;
 ///     use esp_idf_hal::adc::oneshot::*;
 ///     use esp_idf_hal::peripherals::Peripherals;
@@ -492,7 +509,7 @@ impl DirectConverter {
 ///     /// configuring pin to analog read, you can regulate the adc input voltage range depending on your need
 ///     /// for this example we use the attenuation of 11db which sets the input voltage range to around 0-3.6V
 ///     let config = AdcChannelConfig {
-///         attenuation: DB_11,
+///         attenuation: DB_12,
 ///         ..Default::default()
 ///     };
 ///     let mut adc_pin = AdcChannelDriver::new(&adc, peripherals.pins.gpio2, &config)?;
@@ -929,7 +946,7 @@ pub mod oneshot {
 ///     let peripherals = Peripherals::take()?;
 ///     let config = AdcContConfig::default();
 ///
-///     let adc_1_channel_0 = Attenuated::db11(peripherals.pins.gpio0);
+///     let adc_1_channel_0 = Attenuated::db12(peripherals.pins.gpio0);
 ///     let mut adc = AdcContDriver::new(peripherals.adc1, &config, adc_1_channel_0)?;
 ///
 ///     adc.start()?;
@@ -968,7 +985,7 @@ pub mod continuous {
     use super::{attenuation, Adc};
 
     /// Set ADC attenuation level
-    /// Example: let pin = Attenuated::db11(peripherals.pins.gpio0);
+    /// Example: let pin = Attenuated::db12(peripherals.pins.gpio0);
     pub struct Attenuated<const A: adc_atten_t, T>(T);
 
     impl<T> Attenuated<{ attenuation::NONE }, T> {
@@ -990,7 +1007,18 @@ pub mod continuous {
     }
 
     impl<T> Attenuated<{ attenuation::DB_11 }, T> {
+        #[cfg_attr(
+            not(esp_idf_version_major = "4"),
+            deprecated(since = "0.45.3", note = "Use `Attenuated::db12` instead")
+        )]
         pub const fn db11(t: T) -> Self {
+            Self(t)
+        }
+    }
+
+    #[cfg(not(esp_idf_version_major = "4"))]
+    impl<T> Attenuated<{ attenuation::DB_12 }, T> {
+        pub const fn db12(t: T) -> Self {
             Self(t)
         }
     }
@@ -1004,7 +1032,13 @@ pub mod continuous {
     pub type AttenNone<T> = Attenuated<{ attenuation::NONE }, T>;
     pub type Atten2p5dB<T> = Attenuated<{ attenuation::DB_2_5 }, T>;
     pub type Atten6dB<T> = Attenuated<{ attenuation::DB_6 }, T>;
+    #[cfg_attr(
+        not(esp_idf_version_major = "4"),
+        deprecated(since = "0.45.3", note = "Use `Atten12dB` instead")
+    )]
     pub type Atten11dB<T> = Attenuated<{ attenuation::DB_11 }, T>;
+    #[cfg(not(esp_idf_version_major = "4"))]
+    pub type Atten12dB<T> = Attenuated<{ attenuation::DB_12 }, T>;
 
     pub trait AdcChannels {
         type Adc: Adc;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
ESP-IDF 5 deprecated `ADC_ATTEN_DB_11` and introduced `ADC_ATTEN_DB_12`, I think we should reflect that.

#### Testing
-