### PR TITLE
Pcnt example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fade_with_time`, `fade_with_step` for `LedcDriver`
 
 ### Fixed
+- Fix pcnt_rotary_encoder example for esp32
 - Fix the SDMMC driver for ESP-IDF V5.5+
 - Replace Arc with Rc in ledc_threads example (#514)
 - Fix outdated task docs

--- a/examples/pcnt_rotary_encoder.rs
+++ b/examples/pcnt_rotary_encoder.rs
@@ -22,8 +22,8 @@ fn main() -> anyhow::Result<()> {
 
     println!("setup pins");
     let peripherals = Peripherals::take().context("failed to take Peripherals")?;
-    let mut pin_a = peripherals.pins.gpio5;
-    let mut pin_b = peripherals.pins.gpio6;
+    let mut pin_a = peripherals.pins.gpio4;
+    let mut pin_b = peripherals.pins.gpio5;
     println!("setup encoder");
     let encoder = Encoder::new(peripherals.pcnt0, &mut pin_a, &mut pin_b)?;
 


### PR DESCRIPTION
Update pcnt_rotary_encoder example to use gpio4 instead of gpio6 because gpio6 is connected to the integrated SPI flash (SCK/CLK) and causes `PcntDriver::channel_config()` to hang when used on the base esp32 on which it was tested.