### PR TITLE
ledc: add fade stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `Send` for `AsyncCanDriver`
 - `DB_12` ADC attenuation
-- `fade_with_time`, `fade_with_step` for `LedcDriver`
+- `fade_with_time`, `fade_with_step`, `fade_stop` for `LedcDriver`
 
 ### Fixed
 - Fix pcnt_rotary_encoder example for esp32

--- a/examples/ledc_fade.rs
+++ b/examples/ledc_fade.rs
@@ -32,6 +32,16 @@ fn main() -> anyhow::Result<()> {
         ledc_driver.fade_with_time(0, Duration::from_secs(2).as_millis() as i32, true)?;
     }
 
+    // Fade up over 2 seconds, but abort after 1
+    ledc_driver.fade_with_time(
+        ledc_driver.get_max_duty(),
+        Duration::from_secs(2).as_millis() as i32,
+        false,
+    )?;
+    FreeRtos::delay_ms(1000);
+    // Fade will stop halfway
+    ledc_driver.fade_stop()?;
+
     ledc_driver.set_duty(ledc_driver.get_max_duty() / 10)?;
     FreeRtos::delay_ms(10000);
 

--- a/examples/ledc_fade.rs
+++ b/examples/ledc_fade.rs
@@ -32,15 +32,18 @@ fn main() -> anyhow::Result<()> {
         ledc_driver.fade_with_time(0, Duration::from_secs(2).as_millis() as i32, true)?;
     }
 
-    // Fade up over 2 seconds, but abort after 1
-    ledc_driver.fade_with_time(
-        ledc_driver.get_max_duty(),
-        Duration::from_secs(2).as_millis() as i32,
-        false,
-    )?;
-    FreeRtos::delay_ms(1000);
-    // Fade will stop halfway
-    ledc_driver.fade_stop()?;
+    #[cfg(not(esp32))]
+    {
+        // Fade up over 2 seconds, but abort after 1
+        ledc_driver.fade_with_time(
+            ledc_driver.get_max_duty(),
+            Duration::from_secs(2).as_millis() as i32,
+            false,
+        )?;
+        FreeRtos::delay_ms(1000);
+        // Fade will stop halfway
+        ledc_driver.fade_stop()?;
+    }
 
     ledc_driver.set_duty(ledc_driver.get_max_duty() / 10)?;
     FreeRtos::delay_ms(10000);

--- a/examples/ledc_fade.rs
+++ b/examples/ledc_fade.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use esp_idf_hal::delay::FreeRtos;
 use esp_idf_hal::ledc::{config::TimerConfig, LedcDriver, LedcTimerDriver};
 use esp_idf_hal::peripherals::Peripherals;

--- a/examples/ledc_fade.rs
+++ b/examples/ledc_fade.rs
@@ -32,7 +32,7 @@ fn main() -> anyhow::Result<()> {
         ledc_driver.fade_with_time(0, Duration::from_secs(2).as_millis() as i32, true)?;
     }
 
-    #[cfg(not(esp32))]
+    #[cfg(not(any(esp32, esp_idf_version_major = "4")))]
     {
         // Fade up over 2 seconds, but abort after 1
         ledc_driver.fade_with_time(

--- a/src/ledc.rs
+++ b/src/ledc.rs
@@ -385,6 +385,7 @@ impl<'d> LedcDriver<'d> {
         Ok(())
     }
 
+    #[cfg(not(esp32))]
     /// Stop LED fading before target duty cycle is reached
     pub fn fade_stop(&mut self) -> Result<(), EspError> {
         unsafe {

--- a/src/ledc.rs
+++ b/src/ledc.rs
@@ -385,7 +385,7 @@ impl<'d> LedcDriver<'d> {
         Ok(())
     }
 
-    #[cfg(not(esp32))]
+    #[cfg(not(any(esp32, esp_idf_version_major = "4")))]
     /// Stop LED fading before target duty cycle is reached
     pub fn fade_stop(&mut self) -> Result<(), EspError> {
         unsafe {

--- a/src/ledc.rs
+++ b/src/ledc.rs
@@ -384,6 +384,14 @@ impl<'d> LedcDriver<'d> {
         }
         Ok(())
     }
+
+    /// Stop LED fading before target duty cycle is reached
+    pub fn fade_stop(&mut self) -> Result<(), EspError> {
+        unsafe {
+            esp!(ledc_fade_stop(self.speed_mode, self.channel()))?;
+        }
+        Ok(())
+    }
 }
 
 impl Drop for LedcDriver<'_> {


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Added `fade_stop` for `LedcDriver`. This method can be used if fade is started by `fade_with_*` and `wait: false`. Otherwise `set_duty` will be block the thread until target duty is reached.

Following #519

#### Testing
I added new code to ledc_fade.rs example, which shows how to use the new functionality. I have run this successfully on an esp32-s3 SoC with an external led.