### PR TITLE
fix wrong Alert enum indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix the SDMMC driver for ESP-IDF V5.5+
 - Replace Arc with Rc in ledc_threads example (#514)
 - Fix outdated task docs
-- CAN: fix wrong Alert enum indexing (#532)
+- CAN: fix wrong Alert enum indexing / remove wrong TryFromPrimitive derive (#532)
 
 ## [0.45.2] - 2025-01-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ embassy-sync = [] # For now, the dependecy on the `embassy-sync` crate is non-op
 adc-oneshot-legacy = []
 # Similar to adc-oneshot-legacy
 # - When enabled (default), the code for the legacy RMT TX/RX driver will be compiled.
-# - When disabled the code for the new onewire RMT driver will be compiled. 
+# - When disabled the code for the new onewire RMT driver will be compiled.
 rmt-legacy = []
 # Propagated esp-idf-sys features
 native = ["esp-idf-sys/native"]
@@ -55,7 +55,6 @@ embedded-io-async = "0.6"
 esp-idf-sys = { version = "0.36", default-features = false }
 critical-section = { version = "1.1.1", optional = true, features = ["restore-state-none"] }
 heapless = "0.8"
-num_enum = { version = "0.7", default-features = false }
 enumset = { version = "1.1.4", default-features = false }
 log = { version = "0.4", default-features = false }
 atomic-waker = { version = "1.1.1", default-features = false }

--- a/src/can.rs
+++ b/src/can.rs
@@ -364,24 +364,42 @@ pub mod config {
 #[enumset(repr = "u32")]
 #[repr(u32)]
 pub enum Alert {
-    TransmitIdle = 1,
-    Success = 2,
-    Received = 3,
-    BelowErrorWarning = 4,
-    ActiveError = 5,
-    RecoveryInProgress = 6,
-    BusRecovered = 7,
-    ArbLost = 8,
-    AboveErrorWarning = 9,
-    BusError = 10,
-    TransmitFailed = 11,
-    ReceiveQueueFull = 12,
-    ErrorPass = 13,
-    BusOffline = 14,
-    ReceiveFifoOverflow = 15,
-    TransmitRetried = 16,
-    PeripheralReset = 17,
-    AlertAndLog = 18,
+    /// No more messages to transmit
+    TransmitIdle = 0,
+    /// The previous transmission was successful
+    Success = 1,
+    /// A frame has been received and added to the RX queue
+    Received = 2,
+    /// Both error counters have dropped below error warning limit
+    BelowErrorWarning = 3,
+    /// TWAI controller has become error active
+    ActiveError = 4,
+    /// TWAI controller is undergoing bus recovery
+    RecoveryInProgress = 5,
+    /// TWAI controller has successfully completed bus recovery
+    BusRecovered = 6,
+    /// The previous transmission lost arbitration
+    ArbLost = 7,
+    /// One of the error counters have exceeded the error warning limit
+    AboveErrorWarning = 8,
+    /// A (Bit, Stuff, CRC, Form, ACK) error has occurred on the bus
+    BusError = 9,
+    /// The previous transmission has failed (for single shot transmission)
+    TransmitFailed = 10,
+    /// The RX queue is full causing a frame to be lost
+    ReceiveQueueFull = 11,
+    /// TWAI controller has become error passive
+    ErrorPass = 12,
+    /// Bus-off condition occurred. TWAI controller can no longer influence bus
+    BusOffline = 13,
+    /// An RX FIFO overrun has occurred
+    ReceiveFifoOverflow = 14,
+    /// An message transmission was cancelled and retried due to an errata workaround
+    TransmitRetried = 15,
+    /// The TWAI controller was reset
+    PeripheralReset = 16,
+    /// In addition to alerting also Logs the event
+    AlertAndLog = 17,
 }
 
 /// CAN abstraction

--- a/src/can.rs
+++ b/src/can.rs
@@ -41,8 +41,6 @@ use enumset::{EnumSet, EnumSetType};
 
 use esp_idf_sys::*;
 
-use num_enum::TryFromPrimitive;
-
 use crate::cpu::Core;
 use crate::delay::{self, BLOCK, NON_BLOCK};
 use crate::interrupt::InterruptType;
@@ -360,7 +358,7 @@ pub mod config {
     }
 }
 
-#[derive(Debug, EnumSetType, TryFromPrimitive)]
+#[derive(Debug, EnumSetType)]
 #[enumset(repr = "u32")]
 #[repr(u32)]
 pub enum Alert {


### PR DESCRIPTION
closes #532

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

