### PR TITLE
Support for sending UART break conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Send` for `AsyncCanDriver`
 - `DB_12` ADC attenuation
 - `fade_with_time`, `fade_with_step`, `fade_stop` for `LedcDriver`
+- `write_with_break` for `UartDriver` and `UartTxDriver`
 
 ### Fixed
 - Fix pcnt_rotary_encoder example for esp32

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -1374,7 +1374,9 @@ impl<'d> UartTxDriver<'d> {
     /// Write multiple bytes from a slice, then send a break condition.
     pub fn write_with_break(&mut self, bytes: &[u8], brk_len: i32) -> Result<usize, EspError> {
         // `uart_write_bytes_with_break()` returns error (-1) or how many bytes were written
-        let len = unsafe { uart_write_bytes_with_break(self.port(), bytes.as_ptr().cast(), bytes.len(), brk_len) };
+        let len = unsafe {
+            uart_write_bytes_with_break(self.port(), bytes.as_ptr().cast(), bytes.len(), brk_len)
+        };
 
         if len >= 0 {
             Ok(len as usize)

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -885,8 +885,8 @@ impl<'d> UartDriver<'d> {
     }
 
     /// Write multiple bytes from a slice, then send a break condition.
-    pub fn write_with_break(&self, bytes: &[u8]) -> Result<usize, EspError> {
-        self.tx().write_with_break(bytes)
+    pub fn write_with_break(&self, bytes: &[u8], brk_len: i32) -> Result<usize, EspError> {
+        self.tx().write_with_break(bytes, brk_len)
     }
 
     /// Write multiple bytes from a slice directly to the TX FIFO hardware.


### PR DESCRIPTION
### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
This pull request allows for sending  a UART break condition after a write. Ideally, I'd want to just send a break condition, but that functionality is not exposed by esp-idf. This at least allows for parity with esp-idf.

#### Testing
I've manually tested the PR. I'm using this fork in a project that has a UART connection between a ESP32-C6 and an RP2350. Writing with a break triggers the break detection in the RP2350, regular writes don't.