### PR TITLE
Provide an escape hatch for esp-rs/esp-idf-hal#537

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace Arc with Rc in ledc_threads example (#514)
 - Fix outdated task docs
 - CAN: fix wrong Alert enum indexing / remove wrong TryFromPrimitive derive (#532)
+- GPIO: Allow interoperability with other code that initializes the GPIO ISR service (#537)
 
 ## [0.45.2] - 2025-01-15
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1435,7 +1435,7 @@ pub fn enable_isr_service() -> Result<(), EspError> {
 /// # Safety
 ///
 /// The caller must ensure that `gpio_install_isr_service` has already been invoked elsewhere.
-pub unsafe fn isr_service_already_init() {
+pub unsafe fn set_isr_service_flag_unchecked() {
     ISR_SERVICE_ENABLED.store(true, core::sync::atomic::Ordering::SeqCst);
 }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1434,7 +1434,9 @@ pub fn enable_isr_service() -> Result<(), EspError> {
 ///
 /// # Safety
 ///
-/// The caller must ensure that `gpio_install_isr_service` has already been invoked elsewhere.
+/// The caller must ensure that `gpio_install_isr_service` has already
+/// been invoked elsewhere. This should only be ever needed when
+/// interfacing external code that touches the GPIO ISR service.
 pub unsafe fn set_isr_service_flag_unchecked() {
     ISR_SERVICE_ENABLED.store(true, core::sync::atomic::Ordering::SeqCst);
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1429,6 +1429,16 @@ pub fn enable_isr_service() -> Result<(), EspError> {
     Ok(())
 }
 
+/// Notifies this GPIO driver that the GPIO ISR service has already been initialized.
+/// This prevents an error as this driver would otherwise attempt to initialize it again.
+///
+/// # Safety
+///
+/// The caller must ensure that `gpio_install_isr_service` has already been invoked elsewhere.
+pub unsafe fn isr_service_already_init() {
+    ISR_SERVICE_ENABLED.store(true, core::sync::atomic::Ordering::SeqCst);
+}
+
 pub(crate) unsafe fn rtc_reset_pin(pin: i32) -> Result<(), EspError> {
     gpio_reset_without_pull(pin)?;
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Provides an unsafe escape hatch that prevents the HAL GPIO driver from initializing the ISR service a second time.

#### Testing
Not yet tested, but I will do on-device tests this weekend.