### PR TITLE
No longer hide the SD card support behind the "experimental" feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix outdated task docs
 - CAN: fix wrong Alert enum indexing / remove wrong TryFromPrimitive derive (#532)
 - GPIO: Allow interoperability with other code that initializes the GPIO ISR service (#537)
+- SD card support is no longer behind the `experimental` feature
 
 ## [0.45.2] - 2025-01-15
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,6 @@ pub mod prelude;
 pub mod reset;
 pub mod rmt;
 pub mod rom;
-#[cfg(feature = "experimental")]
 pub mod sd;
 pub mod spi;
 pub mod sys;

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -11,7 +11,7 @@ use crate::modem;
 #[cfg(any(esp32, esp32s2, esp32s3, esp32c6))]
 use crate::pcnt;
 use crate::rmt;
-#[cfg(all(esp_idf_soc_sdmmc_host_supported, feature = "experimental"))]
+#[cfg(esp_idf_soc_sdmmc_host_supported)]
 use crate::sd;
 use crate::spi;
 #[cfg(any(
@@ -86,9 +86,9 @@ pub struct Peripherals {
     #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
     pub mac: mac::MAC,
     pub modem: modem::Modem,
-    #[cfg(all(esp_idf_soc_sdmmc_host_supported, feature = "experimental"))]
+    #[cfg(esp_idf_soc_sdmmc_host_supported)]
     pub sdmmc0: sd::mmc::SDMMC0,
-    #[cfg(all(esp_idf_soc_sdmmc_host_supported, feature = "experimental"))]
+    #[cfg(esp_idf_soc_sdmmc_host_supported)]
     pub sdmmc1: sd::mmc::SDMMC1,
     #[cfg(all(esp_idf_soc_temp_sensor_supported, esp_idf_version_major = "5"))]
     pub temp_sensor: temp_sensor::TempSensor,
@@ -191,9 +191,9 @@ impl Peripherals {
             #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
             mac: mac::MAC::new(),
             modem: modem::Modem::new(),
-            #[cfg(all(esp_idf_soc_sdmmc_host_supported, feature = "experimental"))]
+            #[cfg(esp_idf_soc_sdmmc_host_supported)]
             sdmmc0: sd::mmc::SDMMC0::new(),
-            #[cfg(all(esp_idf_soc_sdmmc_host_supported, feature = "experimental"))]
+            #[cfg(esp_idf_soc_sdmmc_host_supported)]
             sdmmc1: sd::mmc::SDMMC1::new(),
             #[cfg(all(esp_idf_soc_temp_sensor_supported, esp_idf_version_major = "5"))]
             temp_sensor: temp_sensor::TempSensor::new(),


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [ ] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description

Subject says it all. I'm actually using the SD card support in production firmware, so I don't think we need to continue hiding it behind the "experimental" feature.

There's a similar PR coming for `esp-idf-svc` which un-hides a bunch of long-standing and I think stable in the meantime features as well.

#### Testing
n/a