### PR TITLE
Implement new RMT driver API

### DIFF
--- a/examples/rmt_morse_code.rs
+++ b/examples/rmt_morse_code.rs
@@ -40,7 +40,7 @@ mod example {
         delay::Ets,
         gpio::{OutputPin, PinDriver},
         peripherals::Peripherals,
-        rmt::{
+        rmt_legacy::{
             config::{CarrierConfig, DutyPercent, Loop, TransmitConfig},
             PinState, Pulse, PulseTicks, RmtChannel, TxRmtDriver, VariableLengthSignal,
         },

--- a/examples/rmt_musical_buzzer.rs
+++ b/examples/rmt_musical_buzzer.rs
@@ -29,7 +29,7 @@ mod example {
     use esp_idf_hal::delay::Ets;
     use esp_idf_hal::{
         peripherals::Peripherals,
-        rmt::{self, config::TransmitConfig, TxRmtDriver},
+        rmt_legacy::{self, config::TransmitConfig, TxRmtDriver},
         units::Hertz,
     };
     use notes::*;

--- a/examples/rmt_neopixel.rs
+++ b/examples/rmt_neopixel.rs
@@ -34,7 +34,7 @@ mod example {
     use esp_idf_hal::{
         delay::FreeRtos,
         peripherals::Peripherals,
-        rmt::{config::TransmitConfig, FixedLengthSignal, PinState, Pulse, TxRmtDriver},
+        rmt_legacy::{config::TransmitConfig, FixedLengthSignal, PinState, Pulse, TxRmtDriver},
     };
 
     pub fn main() -> Result<()> {

--- a/examples/rmt_transceiver.rs
+++ b/examples/rmt_transceiver.rs
@@ -40,7 +40,7 @@ mod example {
     use esp_idf_hal::{
         delay::FreeRtos,
         peripherals::Peripherals,
-        rmt::{
+        rmt_legacy::{
             FixedLengthSignal, PinState, Pulse, PulseTicks, Receive, RmtReceiveConfig,
             RmtTransmitConfig, RxRmtDriver, TxRmtDriver,
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,9 @@ pub mod onewire;
 pub mod pcnt;
 pub mod peripherals;
 pub mod reset;
+#[cfg(not(feature = "rmt-legacy"))]
 pub mod rmt;
+pub mod rmt_legacy;
 pub mod rom;
 pub mod sd;
 pub mod spi;

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -11,7 +11,8 @@ use crate::modem;
 #[cfg(not(esp_idf_version_at_least_6_0_0))]
 #[cfg(any(esp32, esp32s2, esp32s3, esp32c6))]
 use crate::pcnt;
-use crate::rmt;
+#[cfg(feature = "rmt-legacy")]
+use crate::rmt_legacy;
 #[cfg(esp_idf_soc_sdmmc_host_supported)]
 use crate::sd;
 use crate::spi;
@@ -85,7 +86,8 @@ pub struct Peripherals {
     pub ledc: ledc::LEDC,
     #[cfg(esp32)]
     pub hledc: ledc::HLEDC,
-    pub rmt: rmt::RMT,
+    #[cfg(feature = "rmt-legacy")]
+    pub rmt: rmt_legacy::RMT,
     #[cfg(all(
         any(esp32, esp32s2, esp32s3, esp32c6, esp32p4),
         esp_idf_comp_ulp_enabled
@@ -200,7 +202,8 @@ impl Peripherals {
             ledc: ledc::LEDC::new(),
             #[cfg(esp32)]
             hledc: ledc::HLEDC::new(),
-            rmt: rmt::RMT::new(),
+            #[cfg(feature = "rmt-legacy")]
+            rmt: rmt_legacy::RMT::new(),
             #[cfg(all(
                 any(esp32, esp32s2, esp32s3, esp32c6, esp32p4),
                 esp_idf_comp_ulp_enabled

--- a/src/rmt/config.rs
+++ b/src/rmt/config.rs
@@ -1,0 +1,126 @@
+pub use crate::rmt_legacy::config::DutyPercent;
+pub use crate::rmt_legacy::config::Loop;
+
+use crate::rmt::SourceClock;
+use crate::units::{FromValueType, Hertz};
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct TxChannelConfig {
+    /// Selects the source clock for the RMT channel.
+    ///
+    /// Note that, the selected clock is also used by other channels,
+    /// which means the user should ensure this configuration is the
+    /// same when allocating other channels, regardless of TX or RX.
+    /// For the effect on the power consumption of different clock sources,
+    /// please refer to the [Power Management] section.
+    ///
+    /// [Power Management]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/rmt.html#rmt-power-management
+    pub source_clock: SourceClock,
+    /// Sets the resolution of the internal tick counter. The timing parameter
+    /// of the RMT signal is calculated based on this **tick**.
+    pub resolution: Hertz,
+    /// Has a slightly different meaning based on if the DMA backend is enabled or not.
+    ///
+    /// ### With DMA enabled
+    ///
+    /// This field controls the size of the internal DMA buffer. To achieve a better
+    /// throughput and smaller CPU overhead, you can set a larger value, e.g., `1024`.
+    ///
+    /// ### With DMA disabled
+    ///
+    /// This field controls the size of the dedicated memory block owned by the channel,
+    /// which should be at least 64.
+    pub memory_block_symbols: usize,
+    /// Sets the depth of the internal transaction queue, the deeper the queue,
+    /// the more transactions can be prepared in the backlog.
+    pub transaction_queue_depth: usize,
+    /// Set the priority of the interrupt. If set to 0, then the driver will use a
+    /// interrupt with low or medium priority (priority level may be one of 1, 2 or 3),
+    /// otherwise use the priority indicated by `rmt_tx_channel_config_t::intr_priority`.
+    ///
+    /// Please pay attention that once the interrupt priority is set, it cannot be changed
+    /// until the channel is dropped.
+    #[cfg(esp_idf_version_at_least_5_1_2)]
+    pub interrupt_priority: i32,
+    pub flags: TxConfigChannelFlags,
+}
+
+impl Default for TxChannelConfig {
+    fn default() -> Self {
+        Self {
+            source_clock: Default::default(),
+            resolution: 1.MHz().into(),
+            memory_block_symbols: 64,
+            transaction_queue_depth: 4,
+            #[cfg(esp_idf_version_at_least_5_1_2)]
+            interrupt_priority: 0,
+            flags: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct TxConfigChannelFlags {
+    /// Is used to decide whether to invert the RMT signal before sending it to the GPIO pad.
+    pub invert_out: bool,
+    /// Enables the DMA backend for the channel. Using the DMA allows a significant amount of
+    /// the channel's workload to be offloaded from the CPU. However, the DMA backend is not
+    /// available on all ESP chips, please refer to [TRM] before you enable this option.
+    /// Or you might encounter a `ESP_ERR_NOT_SUPPORTED` error.
+    ///
+    /// [TRM]: https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf#rmt
+    pub with_dma: bool,
+    /// The signal output from the GPIO will be fed to the input path as well.
+    pub io_loop_back: bool,
+    /// Configure the GPIO as open-drain mode.
+    pub io_od_mode: bool,
+    /// Configures if the driver allows the system to power down the peripheral in light sleep mode.
+    /// Before entering sleep, the system will backup the RMT register context, which will be restored
+    /// later when the system exit the sleep mode. Powering down the peripheral can save more power,
+    /// but at the cost of more memory consumed to save the register context. It's a tradeoff between
+    /// power consumption and memory consumption. This configuration option relies on specific
+    /// hardware feature, if you enable it on an unsupported chip, you will see error message
+    /// like not able to power down in light sleep.
+    #[cfg(esp_idf_version_at_least_5_4_0)]
+    pub allow_pd: bool,
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct TransmitConfig {
+    /// Specify the times of transmission in a loop, -1 means transmitting in an infinite loop
+    pub loop_count: Loop,
+    /// Set the output level for the "End Of Transmission"
+    pub eot_level: bool,
+    /// If set, when the transaction queue is full, driver will not block the thread but return directly.
+    #[cfg(esp_idf_version_at_least_5_1_3)]
+    pub queue_non_blocking: bool,
+}
+
+// TODO: queue_non_blocking or queue_nonblocking?
+
+impl Default for TransmitConfig {
+    fn default() -> Self {
+        Self {
+            loop_count: Loop::None,
+            eot_level: false,
+            #[cfg(esp_idf_version_at_least_5_1_3)]
+            queue_non_blocking: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct CarrierConfig {
+    /// Carrier wave frequency, in Hz, 0 means disabling the carrier.
+    pub frequency: Hertz,
+    /// Carrier wave duty cycle (0~100%)
+    pub duty_cycle: DutyPercent,
+    /// Specify the polarity of carrier, by default it's modulated to base signal's high level
+    pub polarity_active_low: bool,
+    /// If set, the carrier can always exist even there's not transfer undergoing
+    pub always_on: bool,
+}

--- a/src/rmt/encoder/copy_encoder.rs
+++ b/src/rmt/encoder/copy_encoder.rs
@@ -1,0 +1,33 @@
+use core::ptr;
+
+use esp_idf_sys::*;
+
+use super::Encoder;
+
+#[derive(Debug)]
+pub struct CopyEncoder {
+    handle: rmt_encoder_handle_t,
+}
+
+impl CopyEncoder {
+    pub fn new(config: &rmt_copy_encoder_config_t) -> Result<Self, EspError> {
+        let mut handle: rmt_encoder_handle_t = ptr::null_mut();
+        esp!(unsafe { rmt_new_copy_encoder(config, &mut handle) })?;
+        Ok(Self { handle })
+    }
+}
+
+impl Drop for CopyEncoder {
+    fn drop(&mut self) {
+        // This is calling encoder->del(encoder);
+        unsafe { rmt_del_encoder(self.handle) };
+    }
+}
+
+impl Encoder for CopyEncoder {
+    type Item = rmt_symbol_word_t;
+
+    fn handle(&mut self) -> &mut rmt_encoder_t {
+        unsafe { &mut *self.handle }
+    }
+}

--- a/src/rmt/encoder/mod.rs
+++ b/src/rmt/encoder/mod.rs
@@ -1,0 +1,19 @@
+mod copy_encoder;
+pub use copy_encoder::*;
+
+use esp_idf_sys::*;
+
+/// This trait represents an RMT encoder that is used to encode data for transmission.
+pub trait Encoder {
+    /// The type of input data that the encoder can encode.
+    type Item;
+
+    /// Returns a mutable reference to the underlying `rmt_encoder_t`.
+    ///
+    /// The functions of the `rmt_encoder_t` will be called by the RMT driver.
+    fn handle(&mut self) -> &mut rmt_encoder_t;
+
+    fn reset(&mut self) -> Result<(), EspError> {
+        esp!(unsafe { rmt_encoder_reset(self.handle()) })
+    }
+}

--- a/src/rmt/mod.rs
+++ b/src/rmt/mod.rs
@@ -1,0 +1,100 @@
+pub mod config;
+pub mod encoder;
+
+mod tx_channel;
+pub use tx_channel::*;
+
+// pub type TxDriverConfig
+use esp_idf_sys::*;
+
+use crate::rmt_legacy::Pulse;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum SourceClock {
+    #[default]
+    Default,
+    APB,
+    RcFast,
+    XTAL,
+}
+
+// TODO: RMT_CLK_SRC_REF_TICK is documented, but not in the enum?
+
+impl From<SourceClock> for rmt_clock_source_t {
+    fn from(clock: SourceClock) -> Self {
+        match clock {
+            SourceClock::Default => soc_periph_rmt_clk_src_t_RMT_CLK_SRC_DEFAULT,
+            SourceClock::APB => soc_periph_rmt_clk_src_t_RMT_CLK_SRC_APB,
+            SourceClock::RcFast => soc_periph_rmt_clk_src_t_RMT_CLK_SRC_RC_FAST,
+            SourceClock::XTAL => soc_periph_rmt_clk_src_t_RMT_CLK_SRC_XTAL,
+        }
+    }
+}
+
+// TODO: Decide on how to adjust the signal trait.
+//
+// Why it needs an adjustment?
+//
+// The original api only accepted a pointer to an array of rmt symbols,
+// the new api supports a pointer to any kind of data, as long as it is
+// supported by an encoder.
+//
+// To accommodate this change, the Signal trait has been adjusted to
+// support a generic type T.
+//
+// Depending on the final implementation, one could keep backward compatibility
+// with the old api by defaulting T to rmt_item32_t (I am not a fan of this)
+//
+// Potential problems:
+// - Make sure that Signal owns its data, so the code can assume that when it is
+//   passed an owned value that implements Signal, that the slice it references is
+//   a part of it.
+pub trait Signal<T> {
+    // TODO: associated type instead of generic?
+    fn as_slice(&self) -> &[T];
+}
+
+#[derive(Clone, Copy)]
+pub struct Symbol(rmt_symbol_word_t);
+
+impl Symbol {
+    /// Create a symbol from a pair of half-cycles.
+    pub fn new(level0: Pulse, level1: Pulse) -> Self {
+        let item = rmt_symbol_word_t {
+            __bindgen_anon_1: Default::default(),
+        };
+        let mut this = Self(item);
+        this.update(level0, level1);
+        this
+    }
+
+    /// Mutate this symbol to store a different pair of half-cycles.
+    pub fn update(&mut self, level0: Pulse, level1: Pulse) {
+        // SAFETY: We're overriding all 32 bits, so it doesn't matter what was here before.
+        let inner = unsafe { &mut self.0.__bindgen_anon_1 };
+        inner.set_level0(level0.pin_state as u16);
+        inner.set_duration0(level0.ticks.ticks());
+        inner.set_level1(level1.pin_state as u16);
+        inner.set_duration1(level1.ticks.ticks());
+    }
+}
+
+// TODO: is it safe to transmute between rmt_item32_t and rmt_symbol_word_t?
+
+impl Signal<rmt_symbol_word_t> for Symbol {
+    fn as_slice(&self) -> &[rmt_symbol_word_t] {
+        std::slice::from_ref(&self.0)
+    }
+}
+
+impl Signal<rmt_symbol_word_t> for [rmt_symbol_word_t] {
+    fn as_slice(&self) -> &[rmt_symbol_word_t] {
+        self
+    }
+}
+
+impl Signal<rmt_symbol_word_t> for &[rmt_symbol_word_t] {
+    fn as_slice(&self) -> &[rmt_symbol_word_t] {
+        *self
+    }
+}

--- a/src/rmt/tx_channel.rs
+++ b/src/rmt/tx_channel.rs
@@ -1,0 +1,444 @@
+use core::marker::PhantomData;
+use core::ptr;
+use core::time::Duration;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::gpio::OutputPin;
+use crate::interrupt::asynch::HalIsrNotification;
+
+use esp_idf_sys::*;
+
+use crate::interrupt;
+use crate::rmt::config::{CarrierConfig, Loop, TransmitConfig, TxChannelConfig};
+use crate::rmt::encoder::{CopyEncoder, Encoder};
+use crate::rmt::Signal;
+
+#[must_use]
+pub struct TxHandle<'t, E, S> {
+    channel: &'t TxChannel<'t>,
+    notif: &'t HalIsrNotification,
+    signal: S,
+    id: usize,
+    encoder: E, // Ensures that the encoder lives as long as the TxHandle
+    enabled: bool,
+}
+
+impl<'t, E, S> TxHandle<'t, E, S> {
+    pub async fn wait(&mut self) {
+        self.channel.check();
+
+        // Wait until the transmission with this id is done
+        while TRANSMISSION_COUNTER[self.channel.channel_id()]
+            .sent
+            .load(Ordering::SeqCst)
+            <= self.id
+        {
+            self.notif.wait().await; // Will be notified from the ISR every time a transmission is done
+        }
+    }
+
+    pub fn wait_blocking(&mut self) {
+        // TODO: This might block forever if the transmission never ends; Loop::Endless
+        crate::task::block_on(self.wait())
+    }
+}
+
+// TODO: impl IntoFuture for TxHandle?
+
+impl<'t, E, S> Drop for TxHandle<'t, E, S> {
+    fn drop(&mut self) {
+        if self.enabled {
+            self.wait_blocking()
+        }
+    }
+}
+
+pub struct TxChannel<'d> {
+    handle: rmt_channel_handle_t,
+    _p: PhantomData<&'d mut ()>,
+}
+
+impl<'d> TxChannel<'d> {
+    /// Creates a new RMT TX channel.
+    ///
+    /// # Note
+    ///
+    /// When multiple RMT channels are allocated at the same time,
+    /// the group’s prescale is determined based on the resolution of
+    /// the first channel. The driver then selects the appropriate prescale
+    /// from low to high. To avoid prescale conflicts when allocating multiple
+    /// channels, allocate channels in order of their target resolution,
+    /// either from highest to lowest or lowest to highest.
+    pub fn new(pin: impl OutputPin + 'd, config: &TxChannelConfig) -> Result<Self, EspError> {
+        let sys_config: rmt_tx_channel_config_t = rmt_tx_channel_config_t {
+            clk_src: config.source_clock.into(),
+            resolution_hz: config.resolution.into(),
+            mem_block_symbols: config.memory_block_symbols,
+            trans_queue_depth: config.transaction_queue_depth,
+            #[cfg(esp_idf_version_at_least_5_1_2)]
+            intr_priority: config.interrupt_priority,
+            flags: rmt_tx_channel_config_t__bindgen_ty_1 {
+                _bitfield_1: rmt_tx_channel_config_t__bindgen_ty_1::new_bitfield_1(
+                    config.flags.invert_out as u32,
+                    config.flags.with_dma as u32,
+                    config.flags.io_loop_back as u32,
+                    config.flags.io_od_mode as u32,
+                    #[cfg(esp_idf_version_at_least_5_4_0)]
+                    {
+                        config.flags.allow_pd as u32
+                    },
+                ),
+                ..Default::default()
+            },
+            gpio_num: pin.pin() as _,
+        };
+        let mut handle: rmt_channel_handle_t = core::ptr::null_mut();
+        esp!(unsafe { rmt_new_tx_channel(&sys_config, &mut handle) })?;
+
+        // The callback is used to detect when a transmission is finished.
+        // Therefore it is always registered:
+        esp!(unsafe {
+            rmt_tx_register_event_callbacks(
+                handle,
+                &Self::TX_EVENT_CALLBACKS,
+                core::ptr::null_mut(),
+            )
+        })?;
+
+        Ok(Self {
+            handle,
+            _p: PhantomData,
+        })
+    }
+
+    /// Returns the underlying `rmt_channel_handle_t`.
+    pub fn handle(&self) -> rmt_channel_handle_t {
+        self.handle
+    }
+
+    /// Must be called in advance before transmitting or receiving RMT symbols.
+    /// For TX channels, enabling a channel enables a specific interrupt and
+    /// prepares the hardware to dispatch transactions. For RX channels, enabling
+    /// a channel enables an interrupt, but the receiver is not started during
+    /// this time, as the characteristics of the incoming signal have yet to be
+    /// specified.
+    ///
+    /// The receiver is started in rmt_receive().
+    pub fn enable(&mut self) -> Result<(), EspError> {
+        esp!(unsafe { rmt_enable(self.handle) })?;
+        Ok(())
+    }
+
+    /// Disables the interrupt and clearing any pending interrupts. The transmitter
+    /// and receiver are disabled as well.
+    pub fn disable(&mut self) -> Result<(), EspError> {
+        esp!(unsafe { rmt_disable(self.handle) })
+    }
+
+    /// Wait for all pending TX transactions to finish.
+    ///
+    /// # Note
+    ///
+    /// This function will block forever if the pending transaction can't
+    /// be finished within a limited time (e.g. an infinite loop transaction).
+    /// See also [`Self::disable`] for how to terminate a working channel.
+    ///
+    /// # Errors
+    ///
+    /// - `ESP_ERR_INVALID_ARG`: Flush transactions failed because of invalid argument
+    /// - `ESP_ERR_TIMEOUT`: Flush transactions failed because of timeout
+    /// - `ESP_FAIL`: Flush transactions failed because of other error
+    pub fn wait_all_done(&self, timeout: Option<Duration>) -> Result<(), EspError> {
+        esp!(unsafe {
+            rmt_tx_wait_all_done(
+                self.handle,
+                timeout.map_or(-1, |duration| duration.as_millis() as i32),
+            )
+        })
+    }
+
+    /// Apply modulation feature for the channel.
+    ///
+    /// # Errors
+    ///
+    /// - `ESP_ERR_INVALID_ARG`: Apply carrier failed because of invalid argument
+    /// - `ESP_FAIL`: Apply carrier failed because of other error
+    pub fn apply_carrier(
+        &mut self,
+        carrier_config: Option<&CarrierConfig>,
+    ) -> Result<(), EspError> {
+        let mut sys_carrier = None;
+        if let Some(CarrierConfig {
+            frequency,
+            duty_cycle,
+            polarity_active_low,
+            always_on,
+        }) = carrier_config
+        {
+            sys_carrier = Some(rmt_carrier_config_t {
+                frequency_hz: (*frequency).into(),
+                duty_cycle: duty_cycle.0 as f32 / 100.0,
+                flags: rmt_carrier_config_t__bindgen_ty_1 {
+                    _bitfield_1: rmt_carrier_config_t__bindgen_ty_1::new_bitfield_1(
+                        *polarity_active_low as u32,
+                        *always_on as u32,
+                    ),
+                    ..Default::default()
+                },
+            })
+        }
+
+        esp!(unsafe {
+            rmt_apply_carrier(
+                self.handle,
+                sys_carrier.as_ref().map_or(ptr::null(), |c| c as *const _),
+            )
+        })
+    }
+
+    /// Starts transmitting the given payloadk, it will not wait for the transmission to be done.
+    ///
+    /// # Safety
+    ///
+    /// You are not allowed to `mem::forget` the returned `TxHandle`, this might lead to undefined behavior.
+    pub unsafe fn start_transmit<'t, S>(
+        &'t self,
+        payload: S,
+        config: &TransmitConfig,
+    ) -> Result<TxHandle<'t, CopyEncoder, S>, EspError>
+    where
+        S: Signal<rmt_symbol_word_t>,
+    {
+        let copy_encoder = CopyEncoder::new(&rmt_copy_encoder_config_t {})?;
+        let handle = self.transmit_raw(copy_encoder, payload, config)?;
+
+        Ok(handle)
+    }
+
+    /// Transmits the raw data using the specified encoder and config.
+    ///
+    /// # Safety
+    ///
+    /// The encoder is passed to the [`rmt_transmit`] function which then calls the
+    /// encoders functions to transform the payload into RMT symbols. You must ensure
+    /// that the encoder is implemented correctly, for more details, see the [RMT Encoder]
+    /// documentation.
+    ///
+    /// The passed payload must be valid and can not be modified, until the transmission is done.
+    /// One can await the transmission end by calling [`Self::wait_all_done`] or registering a
+    /// callback to be notified when the transmission is done.
+    ///
+    /// [RMT Encoder]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/rmt.html#rmt-encoder
+    ///
+    /// # Queue blocking behavior
+    ///
+    /// This function constructs a transaction descriptor then pushes to a queue. The transaction
+    /// will not start immediately if there's another one under processing. Based on the setting
+    /// of [`TransmitConfig::queue_non_blocking`], if there're too many transactions pending in the
+    /// queue, this function can block until it has free slot, otherwise just return quickly.
+    ///
+    /// # Errors
+    ///
+    /// - `ESP_ERR_INVALID_ARG`: Transmit failed because of invalid argument
+    /// - `ESP_ERR_INVALID_STATE`: The channel is not enabled, make sure you called [`Self::enable`] before transmitting.
+    /// - `ESP_ERR_NOT_SUPPORTED`: Some feature is not supported by hardware e.g. unsupported loop count
+    /// - `ESP_FAIL`: Because of other errors
+    pub unsafe fn transmit_raw<'t, E: Encoder, S>(
+        &'t self,
+        encoder: E,
+        payload: S,
+        config: &TransmitConfig,
+    ) -> Result<TxHandle<'t, E, S>, EspError>
+    where
+        S: Signal<E::Item>,
+    {
+        let sys_config = rmt_transmit_config_t {
+            loop_count: match config.loop_count {
+                Loop::Count(value) => value as i32,
+                Loop::Endless => -1,
+                Loop::None => 0,
+            },
+            flags: rmt_transmit_config_t__bindgen_ty_1 {
+                _bitfield_1: rmt_transmit_config_t__bindgen_ty_1::new_bitfield_1(
+                    config.eot_level as u32,
+                    #[cfg(esp_idf_version_at_least_5_1_3)]
+                    {
+                        config.queue_non_blocking as u32
+                    },
+                ),
+                ..Default::default()
+            },
+        };
+
+        // TODO: The rmt_transmit might block if the queue is full and queue_non_blocking is false.
+
+        // SAFETY: The payload buffer must not be modified or dropped until the transmission is completed.
+        // SAFETY: The encoder must live until the transmission is completed.
+        //
+        // Both of these conditions are guaranteed by the TxHandle that is returned. This functions signature
+        // ensures that the channel, payload and encoder live at least as long as the TxHandle. When a TxHandle
+        // is dropped, it will wait for the transmission to be done, ensuring that the payload and encoder will
+        // not be dropped before the transmission is done.
+        // TODO: couldn't one forget the TxHandle? This would prevent it from calling the drop function -> not waiting for the transmission to be done?
+        // TODO: maybe define TxHandle such that it owns the data -> on forget the data will still be there?
+        let id = TRANSMISSION_COUNTER[self.channel_id()]
+            .queued
+            .fetch_add(1, Ordering::SeqCst);
+
+        let mut handle = TxHandle {
+            channel: self,
+            notif: &RMT_NOTIF[self.channel_id()],
+            id,
+            encoder,
+            signal: payload,
+            enabled: false,
+        };
+        // TODO: is it enough to keep ownership or do we have to keep the reference in TxHandle as well?
+        let data = handle.signal.as_slice();
+        esp!(unsafe {
+            rmt_transmit(
+                self.handle,
+                handle.encoder.handle(),
+                data.as_ptr() as *const _,
+                // size should be given in bytes:
+                data.len() * core::mem::size_of::<E::Item>(),
+                &sys_config,
+            )
+        })?;
+        // The above might error, in which case the transmission was not started/it should not be waited for.
+        // This field solves that issue.
+        handle.enabled = true;
+
+        Ok(handle)
+    }
+
+    const TX_EVENT_CALLBACKS: rmt_tx_event_callbacks_t = rmt_tx_event_callbacks_t {
+        on_trans_done: Some(Self::handle_isr),
+    };
+    const TX_EVENT_CALLBACKS_DISABLE: rmt_tx_event_callbacks_t = rmt_tx_event_callbacks_t {
+        on_trans_done: None,
+    };
+
+    /// Add ISR handler for when a transmission is done.
+    ///
+    /// The callback will be called with the number of transmitted symbols, including one EOF symbol,
+    /// which is appended by the driver to mark the end of the transmission. For a loop transmission,
+    /// this value only counts for one round.
+    ///
+    /// # Safety
+    ///
+    /// Care should be taken not to call STD, libc or FreeRTOS APIs (except for a few allowed ones)
+    /// in the callback passed to this function, as it is executed in an ISR context.
+    #[cfg(feature = "alloc")]
+    pub unsafe fn subscribe(&mut self, callback: impl FnMut(usize) + Send + 'static) {
+        self.check();
+
+        // TODO: allocate callback in IRAM?
+        // See https://github.com/esp-rs/esp-idf-hal/issues/486
+        let callback: alloc::boxed::Box<dyn FnMut(usize) + Send + 'static> =
+            alloc::boxed::Box::new(callback);
+
+        unsafe {
+            ISR_HANDLERS[self.channel_id()] = Some(callback);
+        }
+    }
+
+    /// Remove the ISR handler for when a transmission is done.
+    pub fn unsubscribe(&mut self) {
+        self.check();
+
+        unsafe {
+            ISR_HANDLERS[self.channel_id()] = None;
+        }
+    }
+
+    /// Handles the ISR event for when a transmission is done.
+    unsafe extern "C" fn handle_isr(
+        channel: rmt_channel_handle_t,
+        event_data: *const rmt_tx_done_event_data_t,
+        _user_data: *mut core::ffi::c_void,
+    ) -> bool {
+        // rmt_channel_handle_t is a `typedef struct rmt_channel_t *rmt_channel_handle_t;`
+        // which should correspond to a *mut rmt_channel_t
+        let id = (channel as *mut rmt_channel_t).read() as usize;
+        let num_symbols = event_data.read().num_symbols;
+
+        // TODO: This might not be safe in ISR?
+        TRANSMISSION_COUNTER[id].sent.fetch_add(1, Ordering::SeqCst);
+
+        interrupt::with_isr_yield_signal(move || {
+            if let Some(handler) = ISR_HANDLERS[id].as_mut() {
+                handler(num_symbols);
+            }
+
+            RMT_NOTIF[id].notify_lsb();
+        })
+    }
+
+    fn channel_id(&self) -> usize {
+        // rmt_channel_handle_t is a `typedef struct rmt_channel_t *rmt_channel_handle_t;`
+        // which should correspond to a *mut rmt_channel_t
+        unsafe { (self.handle as *mut rmt_channel_t).read() as usize }
+    }
+
+    fn check(&self) {
+        if interrupt::active() {
+            panic!("This function cannot be called from an ISR");
+        }
+    }
+}
+
+impl<'d> Drop for TxChannel<'d> {
+    fn drop(&mut self) {
+        // Deleting the channel might fail if it is not disabled first.
+        //
+        // The result is ignored here, because there is nothing we can do about it.
+        let _res = self.disable();
+
+        unsafe {
+            rmt_tx_register_event_callbacks(
+                self.handle,
+                &Self::TX_EVENT_CALLBACKS_DISABLE,
+                core::ptr::null_mut(),
+            )
+        };
+
+        unsafe {
+            ISR_HANDLERS[self.channel_id()] = None;
+        }
+        RMT_NOTIF[self.channel_id()].reset();
+        TRANSMISSION_COUNTER[self.channel_id()].reset();
+
+        unsafe { rmt_del_channel(self.handle) };
+    }
+}
+
+type IsrHandler = Option<alloc::boxed::Box<dyn FnMut(usize)>>;
+static mut ISR_HANDLERS: [IsrHandler; rmt_channel_t_RMT_CHANNEL_MAX as usize] =
+    [const { None }; rmt_channel_t_RMT_CHANNEL_MAX as usize];
+
+static RMT_NOTIF: [interrupt::asynch::HalIsrNotification; rmt_channel_t_RMT_CHANNEL_MAX as usize] =
+    [const { interrupt::asynch::HalIsrNotification::new() }; rmt_channel_t_RMT_CHANNEL_MAX as usize];
+
+struct TransmissionCounter {
+    // TODO: move this into TxChannel?
+    queued: AtomicUsize,
+    sent: AtomicUsize,
+}
+
+impl TransmissionCounter {
+    const fn new() -> Self {
+        Self {
+            queued: AtomicUsize::new(0),
+            sent: AtomicUsize::new(0),
+        }
+    }
+
+    #[inline(always)]
+    fn reset(&self) {
+        self.queued.store(0, Ordering::SeqCst);
+        self.sent.store(0, Ordering::SeqCst);
+    }
+}
+static TRANSMISSION_COUNTER: [TransmissionCounter; rmt_channel_t_RMT_CHANNEL_MAX as usize] =
+    [const { TransmissionCounter::new() }; rmt_channel_t_RMT_CHANNEL_MAX as usize];

--- a/src/rmt_legacy.rs
+++ b/src/rmt_legacy.rs
@@ -253,7 +253,7 @@ pub mod config {
 
     /// A percentage from 0 to 100%, used to specify the duty percentage in [`CarrierConfig`].
     #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-    pub struct DutyPercent(pub(super) u8);
+    pub struct DutyPercent(pub(crate) u8);
 
     impl DutyPercent {
         /// Must be between 0 and 100, otherwise an error is returned.


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [ ] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Changes in the old rmt implementation

I renamed the `rmt` module to `rmt_legacy`. I am not sure what you would like to do with the old module, it could be kept or removed, I was thinking of having it like this:
```rust
#[cfg(feature = "rmt-legacy")]
pub mod rmt_legacy as rmt;
#[cfg(not(feature = "rmt-legacy")]
pub mod rmt;
```

In addition to that, the `DutyPercent(pub(super) u8)` has been changed to `DutyPercent(pub(crate) u8)` (to make the field accessible in the new implementation).

### What is necessary before this PR is ready to be merged?
- [x] Implement TX driver API
- [ ] Implement RX driver API
- [ ] Implement Sync Manager API
- [ ] Add all encoder
- [ ] Adjust tests and examples for the new API
