### PR TITLE
Add missing comma to cfg_attr for `rmt-legacy`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub mod reset;
 pub mod rmt;
 #[cfg(feature = "rmt-legacy")]
 #[cfg_attr(
-    feature = "rmt-legacy"
+    feature = "rmt-legacy",
     deprecated(
         since = "0.46.0",
         note = "use the new `rmt` api by disabling the `rmt-legacy` feature"


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [X] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [ ] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Adds missing comma to cfg_attr in lib.rs for the `rmt-legacy` module. Fixes #558 

#### Testing
- Pulled in dependency that enables the `rmt-legacy` feature ([ws2812-esp32-rmt-driver](https://github.com/cat-in-136/ws2812-esp32-rmt-driver)) then patched `esp-idf-hal` with my fork:
```
esp-idf-hal = { git = "https://github.com/z-jxy/esp-idf-hal", branch = "bugfix/558" }
```

Compilation error is gone