### PR TITLE
Drop should never panic; remove unwrap from SpiDriver Drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CAN: fix wrong Alert enum indexing / remove wrong TryFromPrimitive derive (#532)
 - GPIO: Allow interoperability with other code that initializes the GPIO ISR service (#537)
 - SD card support is no longer behind the `experimental` feature
+- SPI: Do not crash in SpiDriver::Drop implementation.
 
 ## [0.45.2] - 2025-01-15
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -648,7 +648,9 @@ impl<'d> SpiDriver<'d> {
 
 impl Drop for SpiDriver<'_> {
     fn drop(&mut self) {
-        esp!(unsafe { spi_bus_free(self.host()) }).unwrap();
+        if let Err(e) = esp!(unsafe { spi_bus_free(self.host()) }) {
+            ::log::error!("Unable to free spi bus: {e:?}");
+        }
     }
 }
 


### PR DESCRIPTION


## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x ] I have updated existing examples or added new ones (if applicable).
- [ x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
In rust, we should never crash in a Drop implementation. The `unwrap` in the SpiDriver Drop implementation causes a crash when the SPI is not correctly initialized (in my case, when initializing the W5500 ethernet peripheral, the spi device is partially initialized, but the ethernet driver unwraps when it encounters an error calling this Drop). 

So I changed the unwrap into an error log. I am not sure though how exactly we should handle this. So I am open to changing this :) 

#### Testing
I have tested this with an ESP without W55000 connected and happy flow with one connected.