### PR TITLE
Add esp32p4 support.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -22,6 +22,10 @@ rustflags = ["--cfg", "espidf_time64"]
 linker = "ldproxy"
 rustflags = ["--cfg", "espidf_time64"]
 
+[target.riscv32imafc-esp-espidf]
+linker = "ldproxy"
+rustflags = ["--cfg", "espidf_time64"]
+
 [env]
 ESP_IDF_SDKCONFIG_DEFAULTS = ".github/configs/sdkconfig.defaults"
 ESP_IDF_VERSION = "v5.4.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `write_with_break` for `UartDriver` and `UartTxDriver`
 - New RMT API
 - New GPTimer API
+- esp32p4 pins and core command added.
 
 ### Fixed
 - Fix pcnt_rotary_encoder example for esp32
@@ -43,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CAN: fix wrong Alert enum indexing / remove wrong TryFromPrimitive derive (#532)
 - GPIO: Allow interoperability with other code that initializes the GPIO ISR service (#537)
 - SD card support is no longer behind the `experimental` feature
+- Added 6th TX channel config argument for IDF 5.5.2+.
 
 ## [0.45.2] - 2025-01-15
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -43,7 +43,7 @@ macro_rules! impl_adcu {
 }
 
 impl_adcu!(ADCU1: adc_unit_t_ADC_UNIT_1);
-#[cfg(any(esp32, esp32s2, esp32s3, esp32c3))]
+#[cfg(any(esp32, esp32s2, esp32s3, esp32c3, esp32p4))]
 impl_adcu!(ADCU2: adc_unit_t_ADC_UNIT_2);
 
 /// A trait designating the ADC channel
@@ -505,7 +505,7 @@ macro_rules! impl_adc {
 }
 
 impl_adc!(ADC1: ADCU1);
-#[cfg(not(any(esp32c2, esp32h2, esp32c5, esp32c6, esp32c61, esp32p4)))] // TODO: Check for esp32c5 and esp32p4
+#[cfg(not(any(esp32c2, esp32h2, esp32c5, esp32c6, esp32c61)))] // TODO: Check for esp32c5
 impl_adc!(ADC2: ADCU2);
 
 /// Converts a raw reading to mV without using calibration

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,4 +1,4 @@
-#[cfg(any(esp32, esp32s3))]
+#[cfg(any(esp32, esp32s3, esp32p4))]
 use core::arch::asm;
 
 use esp_idf_sys::*;
@@ -12,7 +12,7 @@ pub const CORES: u32 = SOC_CPU_CORES_NUM;
 #[repr(C)]
 pub enum Core {
     Core0 = 0, // PRO on dual-core systems, the one and only CPU on single-core systems
-    #[cfg(any(esp32, esp32s3))]
+    #[cfg(any(esp32, esp32s3, esp32p4))]
     Core1 = 1, // APP on dual-core systems
 }
 
@@ -33,7 +33,7 @@ impl From<i32> for Core {
     fn from(core: i32) -> Self {
         match core {
             0 => Core::Core0,
-            #[cfg(any(esp32, esp32s3))]
+            #[cfg(any(esp32, esp32s3, esp32p4))]
             1 => Core::Core1,
             _ => panic!(),
         }
@@ -56,9 +56,14 @@ pub fn core() -> Core {
     #[cfg(any(esp32, esp32s3, esp32p4))]
     let mut core = 0;
 
-    #[cfg(any(esp32, esp32s3))] // TODO: Need a way to get the running core on esp32p4 in future
+    #[cfg(any(esp32, esp32s3))]
     unsafe {
         asm!("rsr.prid {0}", "extui {0},{0},13,1", out(reg) core);
+    }
+
+    #[cfg(esp32p4)]
+    unsafe {
+        asm!("csrr {0}, mhartid", out(reg) core);
     }
 
     match core {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -2223,7 +2223,7 @@ mod chip {
 
 // TODO: Implement esp32c6 glitch filters
 
-#[cfg(any(esp32c5, esp32c6, esp32c61, esp32p4))] // TODO: Implement proper pin layout for esp32c5, esp32c61 and esp32p4
+#[cfg(any(esp32c5, esp32c6, esp32c61))] // TODO: Implement proper pin layout for esp32c5, esp32c61
 mod chip {
     #[cfg(feature = "alloc")]
     extern crate alloc;
@@ -2350,6 +2350,226 @@ mod chip {
                 gpio28: Gpio28::steal(),
                 gpio29: Gpio29::steal(),
                 gpio30: Gpio30::steal(),
+            }
+        }
+    }
+}
+
+#[cfg(esp32p4)]
+mod chip {
+    #[cfg(feature = "alloc")]
+    extern crate alloc;
+
+    #[cfg(feature = "alloc")]
+    use alloc::boxed::Box;
+
+    use crate::interrupt::asynch::HalIsrNotification;
+
+    use super::*;
+
+    #[allow(clippy::type_complexity)]
+    #[cfg(feature = "alloc")]
+    pub(crate) static mut PIN_ISR_HANDLER: [Option<Box<dyn FnMut() + Send + 'static>>; 54] =
+        [PIN_ISR_INIT; 54];
+
+    #[allow(clippy::type_complexity)]
+    pub(crate) static PIN_NOTIF: [HalIsrNotification; 54] = [PIN_NOTIF_INIT; 54];
+
+    // Any pin can be used as RTC. The documentation mentions that they need to be routed
+    // to the RTC low power system.
+    // ADC1 is available on GPIOs 16-23
+    // ADC2 is available on GPIOs 48-53
+    pin!(Gpio0:0, IO, RTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio1:1, IO, RTC:1, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio2:2, IO, RTC:2, NOADC:NOADC, NODAC:0, TOUCH:1);
+    pin!(Gpio3:3, IO, RTC:3, NOADC:NOADC, NODAC:0, TOUCH:2);
+    pin!(Gpio4:4, IO, RTC:4, NOADC:NOADC, NODAC:0, TOUCH:3);
+    pin!(Gpio5:5, IO, RTC:5, NOADC:NOADC, NODAC:0, TOUCH:4);
+    pin!(Gpio6:6, IO, RTC:6, NOADC:NOADC, NODAC:0, TOUCH:5);
+    pin!(Gpio7:7, IO, RTC:7, NOADC:NOADC, NODAC:0, TOUCH:6);
+    pin!(Gpio8:8, IO, RTC:8, NOADC:NOADC, NODAC:0, TOUCH:7);
+    pin!(Gpio9:9, IO, RTC:9, NOADC:NOADC, NODAC:0, TOUCH:8);
+
+    pin!(Gpio10:10, IO, RTC:10, NOADC:NOADC, NODAC:0, TOUCH:9);
+    pin!(Gpio11:11, IO, RTC:11, NOADC:NOADC, NODAC:0, TOUCH:10);
+    pin!(Gpio12:12, IO, RTC:12, NOADC:NOADC, NODAC:0, TOUCH:11);
+    pin!(Gpio13:13, IO, RTC:13, NOADC:NOADC, NODAC:0, TOUCH:12);
+    pin!(Gpio14:14, IO, RTC:14, NOADC:NOADC, NODAC:0, TOUCH:13);
+    pin!(Gpio15:15, IO, NORTC:0, NOADC:NOADC, NODAC:0, TOUCH:14);
+    pin!(Gpio16:16, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio17:17, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio18:18, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio19:19, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+
+    pin!(Gpio20:20, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio21:21, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio22:22, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio23:23, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio24:24, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio25:25, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio26:26, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio27:27, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio28:28, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio29:29, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+
+    pin!(Gpio30:30, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio31:31, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio32:32, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio33:33, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio34:34, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio35:35, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio36:36, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio37:37, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio38:38, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio39:39, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+
+    pin!(Gpio40:40, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio41:41, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio42:42, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio43:43, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio44:44, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio45:45, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio46:46, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio47:47, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio48:48, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio49:49, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+
+    pin!(Gpio50:50, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio51:51, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio52:52, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio53:53, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+    pin!(Gpio54:54, IO, NORTC:0, NOADC:NOADC, NODAC:0, NOTOUCH:0);
+
+    pub struct Pins {
+        pub gpio0: Gpio0<'static>,
+        pub gpio1: Gpio1<'static>,
+        pub gpio2: Gpio2<'static>,
+        pub gpio3: Gpio3<'static>,
+        pub gpio4: Gpio4<'static>,
+        pub gpio5: Gpio5<'static>,
+        pub gpio6: Gpio6<'static>,
+        pub gpio7: Gpio7<'static>,
+        pub gpio8: Gpio8<'static>,
+        pub gpio9: Gpio9<'static>,
+
+        pub gpio10: Gpio10<'static>,
+        pub gpio11: Gpio11<'static>,
+        pub gpio12: Gpio12<'static>,
+        pub gpio13: Gpio13<'static>,
+        pub gpio14: Gpio14<'static>,
+        pub gpio15: Gpio15<'static>,
+        pub gpio16: Gpio16<'static>,
+        pub gpio17: Gpio17<'static>,
+        pub gpio18: Gpio18<'static>,
+        pub gpio19: Gpio19<'static>,
+
+        pub gpio20: Gpio20<'static>,
+        pub gpio21: Gpio21<'static>,
+        pub gpio22: Gpio22<'static>,
+        pub gpio23: Gpio23<'static>,
+        pub gpio24: Gpio24<'static>,
+        pub gpio25: Gpio25<'static>,
+        pub gpio26: Gpio26<'static>,
+        pub gpio27: Gpio27<'static>,
+        pub gpio28: Gpio28<'static>,
+        pub gpio29: Gpio29<'static>,
+
+        pub gpio30: Gpio30<'static>,
+        pub gpio31: Gpio31<'static>,
+        pub gpio32: Gpio32<'static>,
+        pub gpio33: Gpio33<'static>,
+        pub gpio34: Gpio34<'static>,
+        pub gpio35: Gpio35<'static>,
+        pub gpio36: Gpio36<'static>,
+        pub gpio37: Gpio37<'static>,
+        pub gpio38: Gpio38<'static>,
+        pub gpio39: Gpio39<'static>,
+
+        pub gpio40: Gpio40<'static>,
+        pub gpio41: Gpio41<'static>,
+        pub gpio42: Gpio42<'static>,
+        pub gpio43: Gpio43<'static>,
+        pub gpio44: Gpio44<'static>,
+        pub gpio45: Gpio45<'static>,
+        pub gpio46: Gpio46<'static>,
+        pub gpio47: Gpio47<'static>,
+        pub gpio48: Gpio48<'static>,
+        pub gpio49: Gpio49<'static>,
+
+        pub gpio50: Gpio50<'static>,
+        pub gpio51: Gpio51<'static>,
+        pub gpio52: Gpio52<'static>,
+        pub gpio53: Gpio53<'static>,
+        pub gpio54: Gpio54<'static>,
+    }
+
+    impl Pins {
+        /// # Safety
+        ///
+        /// Care should be taken not to instantiate the Pins structure, if it is
+        /// already instantiated and used elsewhere
+        pub unsafe fn new() -> Self {
+            Self {
+                gpio0: Gpio0::steal(),
+                gpio1: Gpio1::steal(),
+                gpio2: Gpio2::steal(),
+                gpio3: Gpio3::steal(),
+                gpio4: Gpio4::steal(),
+                gpio5: Gpio5::steal(),
+                gpio6: Gpio6::steal(),
+                gpio7: Gpio7::steal(),
+                gpio8: Gpio8::steal(),
+                gpio9: Gpio9::steal(),
+
+                gpio10: Gpio10::steal(),
+                gpio11: Gpio11::steal(),
+                gpio12: Gpio12::steal(),
+                gpio13: Gpio13::steal(),
+                gpio14: Gpio14::steal(),
+                gpio15: Gpio15::steal(),
+                gpio16: Gpio16::steal(),
+                gpio17: Gpio17::steal(),
+                gpio18: Gpio18::steal(),
+                gpio19: Gpio19::steal(),
+
+                gpio20: Gpio20::steal(),
+                gpio21: Gpio21::steal(),
+                gpio22: Gpio22::steal(),
+                gpio23: Gpio23::steal(),
+                gpio24: Gpio24::steal(),
+                gpio25: Gpio25::steal(),
+                gpio26: Gpio26::steal(),
+                gpio27: Gpio27::steal(),
+                gpio28: Gpio28::steal(),
+                gpio29: Gpio29::steal(),
+
+                gpio30: Gpio30::steal(),
+                gpio31: Gpio31::steal(),
+                gpio32: Gpio32::steal(),
+                gpio33: Gpio33::steal(),
+                gpio34: Gpio34::steal(),
+                gpio35: Gpio35::steal(),
+                gpio36: Gpio36::steal(),
+                gpio37: Gpio37::steal(),
+                gpio38: Gpio38::steal(),
+                gpio39: Gpio39::steal(),
+
+                gpio40: Gpio40::steal(),
+                gpio41: Gpio41::steal(),
+                gpio42: Gpio42::steal(),
+                gpio43: Gpio43::steal(),
+                gpio44: Gpio44::steal(),
+                gpio45: Gpio45::steal(),
+                gpio46: Gpio46::steal(),
+                gpio47: Gpio47::steal(),
+                gpio48: Gpio48::steal(),
+                gpio49: Gpio49::steal(),
+
+                gpio50: Gpio50::steal(),
+                gpio51: Gpio51::steal(),
+                gpio52: Gpio52::steal(),
+                gpio53: Gpio53::steal(),
+                gpio54: Gpio54::steal(),
             }
         }
     }

--- a/src/i2s/pdm.rs
+++ b/src/i2s/pdm.rs
@@ -11,6 +11,7 @@
 //! | ESP32-C3           | _not supported_* | I2S0, hardware version 2 |
 //! | ESP32-C6           | _not supported_* | I2S0, hardware version 2 |
 //! | ESP32-H2           | _not supported_* | I2S0, hardware version 2 |
+//! | ESP32-P4           | I2S0             | I2S0, hardware version 2 | ????
 //!
 //! \* These microcontrollers have PDM Rx capabilities but lack a PDM-to-PCM decoder required by the ESP-IDF SDK.
 //!
@@ -428,7 +429,7 @@ pub(super) mod config {
     ///
     /// Other microcontrollers do not support PDM receive mode, or do not have a PDM-to-PCM peripheral that allows for decoding
     /// the PDM data as required by ESP-IDF.
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    #[derive(Clone, Copy, Debug)]
     pub struct PdmRxSlotConfig {
         /// I2S sample data bit width (valid data bits per sample).
         #[allow(dead_code)]
@@ -445,7 +446,33 @@ pub(super) mod config {
         /// Are we using the left, right, or both data slots?
         #[allow(dead_code)]
         pub(super) slot_mask: PdmSlotMask,
+
+        /// High pass filter
+        #[cfg(esp_idf_soc_i2s_supports_pdm_rx_hp_filter)]
+        pub(super) high_pass: Option<HighPassFilter>,
     }
+
+    impl PartialEq for PdmRxSlotConfig {
+        #[cfg(not(esp_idf_soc_i2s_supports_pdm_rx_hp_filter))]
+        fn eq(&self, other: &Self) -> bool {
+            self.data_bit_width == other.data_bit_width
+                && self.slot_bit_width == other.slot_bit_width
+                && self.slot_mode == other.slot_mode
+                && self.slot_mask == other.slot_mask
+        }
+
+        /// Note: Ignoring the high_pass filter that contains a f32 for eq compairson and only checking if its set or not.
+        #[cfg(esp_idf_soc_i2s_supports_pdm_rx_hp_filter)]
+        fn eq(&self, other: &Self) -> bool {
+            self.data_bit_width == other.data_bit_width
+                && self.slot_bit_width == other.slot_bit_width
+                && self.slot_mode == other.slot_mode
+                && self.slot_mask == other.slot_mask
+                && self.high_pass.is_some() == other.high_pass.is_some()
+        }
+    }
+
+    impl Eq for PdmRxSlotConfig {}
 
     impl PdmRxSlotConfig {
         /// Configure the PDM mode channel receive slot configuration for the specified bits per sample and slot mode
@@ -465,6 +492,8 @@ pub(super) mod config {
                 slot_bit_width: SlotBitWidth::Auto,
                 slot_mode,
                 slot_mask,
+                #[cfg(esp_idf_soc_i2s_supports_pdm_rx_hp_filter)]
+                high_pass: None,
             }
         }
 
@@ -490,6 +519,13 @@ pub(super) mod config {
             self
         }
 
+        #[cfg(esp_idf_soc_i2s_supports_pdm_rx_hp_filter)]
+        /// Set the PDM high pass filter
+        pub fn high_pass_filter(mut self, filter: Option<HighPassFilter>) -> Self {
+            self.high_pass = filter;
+            self
+        }
+
         /// Convert this PDM mode channel receive slot configuration into the ESP-IDF SDK `i2s_pdm_rx_slot_config_t`
         /// representation.
         #[cfg(esp_idf_soc_i2s_supports_pdm_rx)]
@@ -501,6 +537,20 @@ pub(super) mod config {
                 slot_bit_width: self.slot_bit_width.as_sdk(),
                 slot_mode: self.slot_mode.as_sdk(),
                 slot_mask: self.slot_mask.as_sdk(),
+                #[cfg(esp_idf_soc_i2s_supports_pdm_rx_hp_filter)]
+                hp_en: self.high_pass.is_some(),
+                #[cfg(esp_idf_soc_i2s_supports_pdm_rx_hp_filter)]
+                hp_cut_off_freq_hz: if let Some(filter) = self.high_pass {
+                    filter.cut_off_freq
+                } else {
+                    185.0
+                },
+                #[cfg(esp_idf_soc_i2s_supports_pdm_rx_hp_filter)]
+                amplify_num: if let Some(filter) = self.high_pass {
+                    filter.amplify_num
+                } else {
+                    1
+                },
                 ..Default::default()
             }
         }
@@ -570,6 +620,40 @@ pub(super) mod config {
                 Self::Right => 1 << 1,
                 Self::Both => (1 << 0) | (1 << 1),
             }
+        }
+    }
+
+    /// PDM RX High Pass Filter
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    pub struct HighPassFilter {
+        /// High pass filter cut-off frequency, range 23.3Hz ~ 185Hz
+        pub(super) cut_off_freq: f32,
+
+        /// The amplification number of the final conversion result
+        ///
+        /// The data that have converted from PDM to PCM module, will time `amplify_num` additionally to amplify the final result.
+        /// Note that it's only a multiplier of the digital PCM data, not the gain of the analog signal.
+        /// range 1~15, default 1
+        pub(super) amplify_num: u32,
+    }
+
+    impl HighPassFilter {
+        /// Set the Filter cut off Frequency.
+        ///
+        /// Note: Range between 23.3Hz ~ 185Hz
+        pub fn cut_off_freq(cut_off_freq: f32) -> Self {
+            Self {
+                cut_off_freq,
+                amplify_num: 1,
+            }
+        }
+
+        /// Set the amplification number of the final conversion result
+        ///
+        /// Range: 1-15
+        pub fn amplify_number(mut self, amplify_num: u32) -> Self {
+            self.amplify_num = amplify_num;
+            self
         }
     }
 

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -187,7 +187,7 @@ fn enter(cs: &IsrCriticalSection) {
     }
 }
 
-#[cfg(not(any(esp32, esp32s2, esp32s3, esp32p4)))]
+#[cfg(not(any(esp32, esp32s2, esp32s3)))]
 #[inline(always)]
 #[link_section = ".iram1.interrupt_exit"]
 fn exit(_cs: &IsrCriticalSection) {
@@ -196,7 +196,7 @@ fn exit(_cs: &IsrCriticalSection) {
     }
 }
 
-#[cfg(any(esp32, esp32s2, esp32s3, esp32p4))]
+#[cfg(any(esp32, esp32s2, esp32s3))]
 #[inline(always)]
 #[link_section = ".iram1.interrupt_exit"]
 fn exit(cs: &IsrCriticalSection) {

--- a/src/rmt/tx_channel.rs
+++ b/src/rmt/tx_channel.rs
@@ -81,6 +81,7 @@ impl<'d> TxChannelDriver<'d> {
                     },
                     #[cfg(any(
                         esp_idf_version_patch_at_least_5_4_3,
+                        esp_idf_version_at_least_5_5_2,
                         esp_idf_version_at_least_6_0_0
                     ))]
                     {

--- a/src/task.rs
+++ b/src/task.rs
@@ -91,17 +91,17 @@ pub fn do_yield() {
             if let Some((yielder, arg)) = interrupt::get_isr_yielder() {
                 yielder(arg);
             } else {
-                #[cfg(any(esp32c3, esp32c2, esp32h2, esp32c5, esp32c6))]
+                #[cfg(any(esp32c3, esp32c2, esp32h2, esp32c5, esp32c6, esp32p4))]
                 vPortYieldFromISR();
 
                 #[cfg(all(
-                    not(any(esp32c3, esp32c2, esp32h2, esp32c5, esp32c6)),
+                    not(any(esp32c3, esp32c2, esp32h2, esp32c5, esp32c6, esp32p4)),
                     esp_idf_version_major = "4"
                 ))]
                 vPortEvaluateYieldFromISR(0);
 
                 #[cfg(all(
-                    not(any(esp32c3, esp32c2, esp32h2, esp32c5, esp32c6, esp32c61)),
+                    not(any(esp32c3, esp32c2, esp32h2, esp32c5, esp32c6, esp32c61, esp32p4)),
                     not(esp_idf_version_major = "4")
                 ))]
                 _frxt_setup_switch();


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
I've built off of https://github.com/esp-rs/esp-idf-hal/pull/467 and added in the new pins documented here: https://docs.espressif.com/projects/esp-idf/en/stable/esp32p4/api-reference/peripherals/gpio.html

I'm not totally certain about the RTC pin mapping, but my justification for the choices made will be seen in the testing section.

#### Testing

I generated a project using the esp-idf-template and munged it to point to esp32p4. Note that I had to use `esptool` to flash it, as `espflash` produces a corrupted binary on the chip. I ran the following `main.rs`:

```rust
use esp_idf_svc::hal::cpu;

fn main() {
    //esp_idf_svc::sys::link_patches();
    esp_idf_svc::log::EspLogger::initialize_default();

    log::info!("Hello, world! Core: {:?}", cpu::core());

    // Check which GPIO pins are valid for RTC use
    log::info!("Checking RTC GPIO validity for all 55 GPIO pins...");
    let mut valid_rtc_pins = Vec::new();
    let mut invalid_rtc_pins = Vec::new();

    for gpio_num in 0..55 {
        let is_valid = unsafe {
            esp_idf_svc::sys::rtc_gpio_is_valid_gpio(gpio_num as esp_idf_svc::sys::gpio_num_t)
        };
        
        if is_valid {
            valid_rtc_pins.push(gpio_num);
            log::info!("GPIO{} is valid for RTC use", gpio_num);
        } else {
            invalid_rtc_pins.push(gpio_num);
        }
    }

    log::info!("Summary: {} valid RTC GPIO pins: {:?}", valid_rtc_pins.len(), valid_rtc_pins);
    log::info!("Summary: {} invalid RTC GPIO pins: {:?}", invalid_rtc_pins.len(), invalid_rtc_pins);
}

```

And got the following output after flashing with esptool:

```
➜  osc-pedal git:(master) ✗ espflash monitor --no-stub
[2026-01-04T06:14:17Z INFO ] Serial port: '/dev/ttyACM0'
[2026-01-04T06:14:17Z INFO ] Connecting...
Commands:
    CTRL+R    Reset chip
    CTRL+C    Exit

ESP-ROM:esp32p4-eco2-20240710
Build:Jul 10 2024
rst:0x1 (POWERON),boot:0x10f (SPI_FAST_FLASH_BOOT)
SPI mode:DIO, clock div:2
load:0x4ff33ce0,len:0x164c
load:0x4ff29ed0,len:0xe08
load:0x4ff2cbd0,len:0x33c4
entry 0x4ff29eda
I (27) boot: ESP-IDF v5.5.1-838-gd66ebb86d2e 2nd stage bootloader
I (28) boot: compile time Nov 26 2025 12:27:01
I (28) boot: Multicore bootloader
I (30) boot: chip revision: v1.3
I (32) boot: efuse block revision: v0.3
I (36) boot.esp32p4: SPI Speed      : 40MHz
I (39) boot.esp32p4: SPI Mode       : DIO
I (43) boot.esp32p4: SPI Flash Size : 32MB
I (47) boot: Enabling RNG early entropy source...
I (52) boot: Partition Table:
I (54) boot: ## Label            Usage          Type ST Offset   Length
I (60) boot:  0 nvs              WiFi data        01 02 00009000 00006000
I (67) boot:  1 phy_init         RF data          01 01 0000f000 00001000
I (73) boot:  2 factory          factory app      00 00 00010000 00fa0000
I (81) boot: End of partition table
I (83) esp_image: segment 0: paddr=00010020 vaddr=40050020 size=12e48h ( 77384) map
I (108) esp_image: segment 1: paddr=00022e70 vaddr=30100000 size=00044h (    68) load
I (110) esp_image: segment 2: paddr=00022ebc vaddr=4ff00000 size=0d138h ( 53560) load
I (126) esp_image: segment 3: paddr=0002fffc vaddr=4ff0d180 size=0001ch (    28) load
I (128) esp_image: segment 4: paddr=00030020 vaddr=40000020 size=47438h (291896) map
I (193) esp_image: segment 5: paddr=00077460 vaddr=4ff0d19c size=0255ch (  9564) load
I (199) boot: Loaded app from partition at offset 0x10000
I (200) boot: Disabling RNG early entropy source...
I (213) cpu_start: Multicore app
I (223) cpu_start: Pro cpu start user code
I (223) cpu_start: cpu freq: 360000000 Hz
I (223) app_init: Application information:
I (224) app_init: Project name:     libespidf
I (227) app_init: App version:      1
I (231) app_init: Compile time:     Jan  4 2026 01:13:24
I (236) app_init: ELF file SHA256:  af6edb7e4...
I (240) app_init: ESP-IDF:          v5.5.1
I (244) efuse_init: Min chip rev:     v0.1
I (248) efuse_init: Max chip rev:     v1.99
I (252) efuse_init: Chip rev:         v1.3
I (256) heap_init: Initializing. RAM available for dynamic allocation:
I (262) heap_init: At 4FF10F70 len 0002A050 (168 KiB): RAM
I (267) heap_init: At 4FF3AFC0 len 00004BF0 (18 KiB): RAM
I (272) heap_init: At 4FF40000 len 00060000 (384 KiB): RAM
I (277) heap_init: At 50108080 len 00007F80 (31 KiB): RTCRAM
I (283) heap_init: At 30100044 len 00001FBC (7 KiB): TCM
I (289) spi_flash: detected chip: gd
I (291) spi_flash: flash io: dio
I (295) main_task: Started on CPU0
I (345) main_task: Calling app_main()
I (345) osc_pedal: Hello, world! Core: Core0
I (345) osc_pedal: Checking RTC GPIO validity for all 55 GPIO pins...
I (345) osc_pedal: GPIO0 is valid for RTC use
I (355) osc_pedal: GPIO1 is valid for RTC use
I (355) osc_pedal: GPIO2 is valid for RTC use
I (365) osc_pedal: GPIO3 is valid for RTC use
I (365) osc_pedal: GPIO4 is valid for RTC use
I (365) osc_pedal: GPIO5 is valid for RTC use
I (375) osc_pedal: GPIO6 is valid for RTC use
I (375) osc_pedal: GPIO7 is valid for RTC use
I (385) osc_pedal: GPIO8 is valid for RTC use
I (385) osc_pedal: GPIO9 is valid for RTC use
I (385) osc_pedal: GPIO10 is valid for RTC use
I (395) osc_pedal: GPIO11 is valid for RTC use
I (395) osc_pedal: GPIO12 is valid for RTC use
I (405) osc_pedal: GPIO13 is valid for RTC use
I (405) osc_pedal: GPIO14 is valid for RTC use
I (405) osc_pedal: GPIO15 is valid for RTC use
I (415) osc_pedal: Summary: 16 valid RTC GPIO pins: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
I (425) osc_pedal: Summary: 39 invalid RTC GPIO pins: [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54]
I (445) main_task: Returned from app_main()
```