### PR TITLE
Remove the modem peripheral from esp32p4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New RMT API
 - New GPTimer API
 - esp32p4 pins and core command added.
+- Removed the modem peripheral for esp32p4
 
 ### Fixed
 - Fix pcnt_rotary_encoder example for esp32

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod io;
 pub mod ledc;
 #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
 pub mod mac;
+#[cfg(not(esp32p4))]
 pub mod modem;
 #[cfg(all(
     esp_idf_soc_rmt_supported,

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -7,6 +7,7 @@ use crate::i2s;
 use crate::ledc;
 #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
 use crate::mac;
+#[cfg(not(esp32p4))]
 use crate::modem;
 #[cfg(not(esp_idf_version_at_least_6_0_0))]
 #[cfg(all(
@@ -110,6 +111,7 @@ pub struct Peripherals {
     pub ulp: ulp::ULP<'static>,
     #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
     pub mac: mac::MAC<'static>,
+    #[cfg(not(esp32p4))]
     pub modem: modem::Modem<'static>,
     #[cfg(esp_idf_soc_sdmmc_host_supported)]
     pub sdmmc0: sd::mmc::SDMMC0<'static>,
@@ -238,6 +240,7 @@ impl Peripherals {
             ulp: ulp::ULP::steal(),
             #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
             mac: mac::MAC::steal(),
+            #[cfg(not(esp32p4))]
             modem: modem::Modem::steal(),
             #[cfg(esp_idf_soc_sdmmc_host_supported)]
             sdmmc0: sd::mmc::SDMMC0::steal(),


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
The esp32p4 doesn't have a radio, so the modem peripheral has been removed for esp32p4.

#### Testing
Compiled against the esp32p4. trying to access modem:

```
    let peripherals = esp_idf_svc::hal::peripherals::Peripherals::take().unwrap();
    peripherals.modem.power_on();
```

```
error[E0609]: no field `modem` on type `Peripherals`
  --> src/main.rs:28:17
   |
28 |     peripherals.modem.power_on();
   |                 ^^^^^ unknown field
   |
   = note: available fields are: `pins`, `uart0`, `uart1`, `i2c0`, `i2c1` ... and 12 others

For more information about this error, try `rustc --explain E0609`.
error: could not compile `osc-pedal` (bin "osc-pedal") due to 1 previous error
```