### PR TITLE
Use vPortExitCriticalMultiCore for esp32p4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GPIO: Allow interoperability with other code that initializes the GPIO ISR service (#537)
 - SD card support is no longer behind the `experimental` feature
 - Added 6th TX channel config argument for IDF 5.5.2+.
+- esp32p4 uses vPortExitCriticalMultiCore instead of vPortExitCritical
 
 ## [0.45.2] - 2025-01-15
 

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -187,7 +187,7 @@ fn enter(cs: &IsrCriticalSection) {
     }
 }
 
-#[cfg(not(any(esp32, esp32s2, esp32s3)))]
+#[cfg(not(any(esp32, esp32s2, esp32s3, esp32p4)))]
 #[inline(always)]
 #[link_section = ".iram1.interrupt_exit"]
 fn exit(_cs: &IsrCriticalSection) {
@@ -202,6 +202,15 @@ fn exit(_cs: &IsrCriticalSection) {
 fn exit(cs: &IsrCriticalSection) {
     unsafe {
         vPortExitCritical(cs.0.get());
+    }
+}
+
+#[cfg(esp32p4)]
+#[inline(always)]
+#[link_section = ".iram1.interrupt_exit"]
+fn exit(cs: &IsrCriticalSection) {
+    unsafe {
+        vPortExitCriticalMultiCore(cs.0.get());
     }
 }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
The esp32p4 now uses vPortExitCriticalMultiCore to exit a critical section rather than vPortExitCritical. vPortExitCritical will fail with the following (misleading) message:

```
PortExitCritical(void) is not supported on single-core targets. Please use vPortExitCriticalMultiCore(portMUX_TYPE *mux) instead.
```

Note that it says "single-core" but it means "multi-core." Also, note that we're already doing the correct thing for entering the critical section for the esp32p4, it's only the exit that's a problem just now.

#### Testing
While testing against a small SPI OLED screen, before this change I got:

```
I (1516) main_task: Calling app_main()
I (1516) osc_pedal: Starting SSD1322 OLED test (raw SPI)
vPortExitCritical(void) is not supported on single-core targets. Please use vPortExitCriticalMultiCore(portMUX_TYPE *mux) instead.
```

After this change, I got:

```
I (1521) osc_pedal: Starting SSD1322 OLED test (raw SPI)
I (1531) osc_pedal: Configuring SPI pins...
I (1531) osc_pedal: Resetting display...
I (1551) osc_pedal: Sending basic SSD1322 init sequence...
I (1551) osc_pedal: Filling display RAM with a pattern...
I (1561) osc_pedal: Test pattern written. You should see vertical stripes or a filled pattern.
```

And I saw the test pattern successfully on the OLED screen.