### PR TITLE
Add support for PLL_F48M UART clock source on ESP32-H2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - esp32p4 pins and core command added.
 - Removed the modem peripheral for esp32p4
 - LDO support for esp32p4
+- Support for `PLL_F48M` UART clock source on ESP32-H2
 
 ### Fixed
 - Fix pcnt_rotary_encoder example for esp32
 - Fix the SDMMC driver for ESP-IDF V5.5+
+- Fix UART initialization panic on ESP32-H2 with ESP-IDF 5.x due to unsupported `PLL_F48M` clock source
 - Replace Arc with Rc in ledc_threads example (#514)
 - Fix outdated task docs
 - CAN: fix wrong Alert enum indexing / remove wrong TryFromPrimitive derive (#532)

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -243,10 +243,20 @@ pub mod config {
         /// UART source clock from `XTAL`
         #[cfg(esp_idf_soc_uart_support_xtal_clk)]
         Crystal,
-        /// UART source clock from `XTAL`
+        /// UART source clock from `PLL_F80M`
         #[allow(non_camel_case_types)]
         #[cfg(esp_idf_soc_uart_support_pll_f80m_clk)]
         PLL_F80M,
+        /// UART source clock from `PLL_F48M` (ESP32-H2)
+        #[allow(non_camel_case_types)]
+        #[cfg(not(any(
+            esp_idf_soc_uart_support_apb_clk,
+            esp_idf_soc_uart_support_pll_f40m_clk,
+            esp_idf_soc_uart_support_pll_f80m_clk,
+            esp_idf_soc_uart_support_ref_tick,
+            esp_idf_version_major = "4"
+        )))]
+        PLL_F48M,
         /// UART source clock from `REF_TICK`
         #[cfg(esp_idf_soc_uart_support_ref_tick)]
         RefTick,
@@ -275,6 +285,14 @@ pub mod config {
                 XTAL_SCLK => SourceClock::Crystal,
                 #[cfg(esp_idf_soc_uart_support_pll_f80m_clk)]
                 PLL_F80M_SCLK => SourceClock::PLL_F80M,
+                #[cfg(not(any(
+                    esp_idf_soc_uart_support_apb_clk,
+                    esp_idf_soc_uart_support_pll_f40m_clk,
+                    esp_idf_soc_uart_support_pll_f80m_clk,
+                    esp_idf_soc_uart_support_ref_tick,
+                    esp_idf_version_major = "4"
+                )))]
+                PLL_F48M_SCLK => SourceClock::PLL_F48M,
                 #[cfg(esp_idf_soc_uart_support_ref_tick)]
                 REF_TICK_SCLK => SourceClock::RefTick,
                 _ => unreachable!(),
@@ -320,6 +338,17 @@ pub mod config {
     #[cfg(all(esp_idf_version_major = "4", esp_idf_soc_uart_support_pll_f80m_clk))]
     const PLL_F80M_SCLK: uart_sclk_t = uart_sclk_t_UART_SCLK_PLL_F80M;
 
+    #[cfg(all(
+        not(esp_idf_version_major = "4"),
+        not(any(
+            esp_idf_soc_uart_support_apb_clk,
+            esp_idf_soc_uart_support_pll_f40m_clk,
+            esp_idf_soc_uart_support_pll_f80m_clk,
+            esp_idf_soc_uart_support_ref_tick
+        ))
+    ))]
+    const PLL_F48M_SCLK: uart_sclk_t = soc_periph_uart_clk_src_legacy_t_UART_SCLK_PLL_F48M;
+
     #[cfg(all(not(esp_idf_version_major = "4"), esp_idf_soc_uart_support_ref_tick))]
     const REF_TICK_SCLK: uart_sclk_t = soc_periph_uart_clk_src_legacy_t_UART_SCLK_REF_TICK;
     #[cfg(all(esp_idf_version_major = "4", esp_idf_soc_uart_support_ref_tick))]
@@ -346,6 +375,14 @@ pub mod config {
                 SourceClock::Crystal => XTAL_SCLK,
                 #[cfg(esp_idf_soc_uart_support_pll_f80m_clk)]
                 SourceClock::PLL_F80M => PLL_F80M_SCLK,
+                #[cfg(not(any(
+                    esp_idf_soc_uart_support_apb_clk,
+                    esp_idf_soc_uart_support_pll_f40m_clk,
+                    esp_idf_soc_uart_support_pll_f80m_clk,
+                    esp_idf_soc_uart_support_ref_tick,
+                    esp_idf_version_major = "4"
+                )))]
+                SourceClock::PLL_F48M => PLL_F48M_SCLK,
                 #[cfg(esp_idf_soc_uart_support_ref_tick)]
                 SourceClock::RefTick => REF_TICK_SCLK,
             }


### PR DESCRIPTION
## Problem
ESP32-H2 uses PLL_F48M as the default UART clock source, but this was not supported by the HAL, causing panics during UART initialization.

This adds PLL_F48M to the SourceClock enum and implements all necessary conversions. The new clock source is conditionally compiled only for chips that don't have other specific clock support flags (currently ESP32-H2).

Fixes UART initialization panics on ESP32-H2 with ESP-IDF 5.x.

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Please provide a clear and concise description of your changes, including the motivation behind these changes. The context is crucial for the reviewers.

#### Testing
Describe how you tested your changes.