### PR TITLE
Make modem peripheral work on esp32p4 with esp_wifi_remote.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New GPTimer API
 - esp32p4 pins and core command added.
 - Support for esp32c5 and esp32c61
-- Removed the modem peripheral for esp32p4
+- Made the modem peripheral for esp32p4 dependent on esp_wifi_remote
 - LDO support for esp32p4
 - Support for `PLL_F48M` UART clock source on ESP32-H2
 - LCD driver support; DSI peripheral support with the LCD driver for esp32p4

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub mod ldo;
 pub mod ledc;
 #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
 pub mod mac;
-#[cfg(not(esp32p4))]
+#[cfg(any(not(esp32p4), esp_idf_comp_espressif__esp_wifi_remote_enabled))]
 pub mod modem;
 #[cfg(all(
     esp_idf_soc_rmt_supported,

--- a/src/modem.rs
+++ b/src/modem.rs
@@ -16,12 +16,12 @@ impl_peripheral!(Modem);
 
 #[allow(clippy::needless_lifetimes)]
 impl<'d> Modem<'d> {
-    #[cfg(not(any(esp32s2, esp32h2, esp32h4, esp32c5, esp32c6, esp32c61)))]
+    #[cfg(not(any(esp32s2, esp32h2, esp32h4, esp32c5, esp32c6, esp32c61, esp32p4)))]
     pub fn split(self) -> (WifiModem<'d>, BluetoothModem<'d>) {
         unsafe { (WifiModem::steal(), BluetoothModem::steal()) }
     }
 
-    #[cfg(not(any(esp32s2, esp32h2, esp32h4, esp32c5, esp32c6, esp32c61)))]
+    #[cfg(not(any(esp32s2, esp32h2, esp32h4, esp32c5, esp32c6, esp32c61, esp32p4)))]
     pub fn split_reborrow(&mut self) -> (WifiModem<'_>, BluetoothModem<'_>) {
         unsafe { (WifiModem::steal(), BluetoothModem::steal()) }
     }
@@ -65,7 +65,7 @@ impl WifiModemPeripheral for Modem<'_> {}
 #[cfg(any(esp32h2, esp32c5, esp32c6, esp32c61))]
 impl ThreadModemPeripheral for Modem<'_> {}
 
-#[cfg(not(esp32s2))]
+#[cfg(not(any(esp32s2, esp32p4)))]
 impl BluetoothModemPeripheral for Modem<'_> {}
 
 #[cfg(not(esp32s2))]

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -11,7 +11,7 @@ use crate::ldo;
 use crate::ledc;
 #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
 use crate::mac;
-#[cfg(not(esp32p4))]
+#[cfg(any(not(esp32p4), esp_idf_comp_espressif__esp_wifi_remote_enabled))]
 use crate::modem;
 #[cfg(not(esp_idf_version_at_least_6_0_0))]
 #[cfg(all(
@@ -125,7 +125,7 @@ pub struct Peripherals {
     pub ulp: ulp::ULP<'static>,
     #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
     pub mac: mac::MAC<'static>,
-    #[cfg(not(esp32p4))]
+    #[cfg(any(not(esp32p4), esp_idf_comp_espressif__esp_wifi_remote_enabled))]
     pub modem: modem::Modem<'static>,
     #[cfg(esp_idf_soc_sdmmc_host_supported)]
     pub sdmmc0: sd::mmc::SDMMC0<'static>,
@@ -264,7 +264,7 @@ impl Peripherals {
             ulp: ulp::ULP::steal(),
             #[cfg(any(all(esp32, esp_idf_eth_use_esp32_emac), esp_idf_eth_use_openeth))]
             mac: mac::MAC::steal(),
-            #[cfg(not(esp32p4))]
+            #[cfg(any(not(esp32p4), esp_idf_comp_espressif__esp_wifi_remote_enabled))]
             modem: modem::Modem::steal(),
             #[cfg(esp_idf_soc_sdmmc_host_supported)]
             sdmmc0: sd::mmc::SDMMC0::steal(),


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
With esp_wifi_remote, the modem peripheral can work as expected on esp32p4. This peripheral is now gated around the presence of the esp_wifi_remote component for esp32p4.

#### Testing
Using a few other changes:

```
W (3766) rpc_utils: Event: SSID nerds
I (3787) osc_pedal: Starting WiFi...
I (3894) RPC_WRAP: ESP Event: wifi station started
I (3914) RPC_WRAP: ESP Event: wifi station started
I (4030) osc_pedal: WiFi started. Connecting...
I (4030) H_API: esp_wifi_remote_connect
I (6941) RPC_WRAP: ESP Event: Station mode: Connected
I (6941) esp_wifi_remote: esp_wifi_internal_reg_rxcb: sta: 0x40077b54
I (6969) osc_pedal: WiFi connected. Waiting for network interface...
I (7954) esp_netif_handlers: sta ip: 192.168.1.130, mask: 255.255.0.0, gw: 192.168.1.1
I (7982) osc_pedal: WiFi connected! IP: 192.168.1.130
I (7982) osc_pedal: WiFi test passed!
```

Related to:
- https://github.com/esp-rs/esp-idf-svc/pull/640
- https://github.com/esp-rs/esp-idf-sys/pull/404