### PR TITLE
ci-esp-idf-next.yml: Remove 4.0 support, patch embuild for 6.0.0+ support

### DIFF
--- a/.github/workflows/ci-esp-idf-next.yml
+++ b/.github/workflows/ci-esp-idf-next.yml
@@ -52,28 +52,28 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ matrix.idf-version != 'release/v4.4' && '--cfg espidf_time64' || matrix.idf-version == 'release/v4.4' && '--cfg espidf_time32' }}"
+          RUSTFLAGS: "--cfg espidf_time64"
         run: cargo clippy --features experimental --no-deps --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -- -Dwarnings
 
       - name: Build | Compile, all
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ matrix.idf-version != 'release/v4.4' && '--cfg espidf_time64' || matrix.idf-version == 'release/v4.4' && '--cfg espidf_time32' }}"
+          RUSTFLAGS: "--cfg espidf_time64"
         run: cargo build --target ${{ matrix.target }} --features nightly,experimental,critical-section,embassy-sync -Zbuild-std=std,panic_abort
 
       - name: Build | Compile, no_std
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ matrix.idf-version != 'release/v4.4' && '--cfg espidf_time64' || matrix.idf-version == 'release/v4.4' && '--cfg espidf_time32' }}"
+          RUSTFLAGS: "--cfg espidf_time64"
         run: cargo build --no-default-features --features experimental --target ${{ matrix.target }} -Zbuild-std=std,panic_abort
 
       - name: Build | Compile, no_std, alloc
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ matrix.idf-version != 'release/v4.4' && '--cfg espidf_time64' || matrix.idf-version == 'release/v4.4' && '--cfg espidf_time32' }}"
+          RUSTFLAGS: "--cfg espidf_time64"
         run: cargo build --features alloc --no-default-features --features experimental --target ${{ matrix.target }} -Zbuild-std=std,panic_abort
 
       - name: Setup | ldproxy
@@ -87,12 +87,12 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ matrix.idf-version != 'release/v4.4' && '--cfg espidf_time64' || matrix.idf-version == 'release/v4.4' && '--cfg espidf_time32' }}"
+          RUSTFLAGS: "--cfg espidf_time64"
         run: cargo clippy --examples --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -- -Dwarnings
 
       - name: Build | Examples
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ matrix.idf-version != 'release/v4.4' && '--cfg espidf_time64' || matrix.idf-version == 'release/v4.4' && '--cfg espidf_time32' }}"
+          RUSTFLAGS: "--cfg espidf_time64"
         run: cargo build --examples --target ${{ matrix.target }} -Zbuild-std=std,panic_abort

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,3 +83,4 @@ embedded-graphics = "0.7.1"
 # TODO: Remove this before next release, needed for IDF 6.0+ support
 [patch.crates-io]
 esp-idf-sys = { git = "https://github.com/esp-rs/esp-idf-sys", branch = "master" }
+embuild = { git = "https://github.com/esp-rs/embuild", branch = "master" } # IDF >6.0.0 strictly


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section. => CI only

### Pull Request Details 📖

#### Description
Remove 4.x support in esp-idf next CI. Pin embuild to fix release/6.0 build.

#### Testing
https://github.com/drinkcat/esp-idf-hal/actions/runs/23687032707 not exactly the same branch, but similar. release/6.0 is good, master is broken.