### PR TITLE
fix(sd): support sdmmc_host_t field added in ESP-IDF v6.0.1

### DIFF
--- a/src/sd.rs
+++ b/src/sd.rs
@@ -327,6 +327,8 @@ mod sdcard {
                     all(esp_idf_version_major = "5", esp_idf_version_minor = "3"),
                 )))] // For ESP-IDF v5.4 and later
                 is_slot_set_to_uhs1: None,
+                #[cfg(esp_idf_version_at_least_6_0_1)]
+                unaligned_multi_block_rw_max_chunk_size: 0,
             };
 
             let mut card: alloc::boxed::Box<sdmmc_card_t> = Default::default();
@@ -431,6 +433,8 @@ mod sdcard {
                     all(esp_idf_version_major = "5", esp_idf_version_minor = "3"),
                 )))] // For ESP-IDF v5.4 and later
                 is_slot_set_to_uhs1: None,
+                #[cfg(esp_idf_version_at_least_6_0_1)]
+                unaligned_multi_block_rw_max_chunk_size: 0,
             };
 
             let mut card: alloc::boxed::Box<sdmmc_card_t> = Default::default();


### PR DESCRIPTION
ESP-IDF v6.0.1 added `unaligned_multi_block_rw_max_chunk_size` to sdmmc_host_t. Add a `#[cfg(esp_idf_version_at_least_6_0_1)]`-gated field initializer (value 0, matching the C default) to both SdCardDriver::new_spi() and SdCardDriver::new_mmc() so the crate builds against ESP-IDF v6.0.1+ without breaking older IDF versions.

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [ ] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Please provide a clear and concise description of your changes, including the motivation behind these changes. The context is crucial for the reviewers.

#### Testing
Describe how you tested your changes.