### PR TITLE
Fix async SPI transactions hanging forever on multi-core chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed issue 502 - some ADC/RTC pins for esp32c5 and esp32c6 had mapping errors
+- Fixed async SPI transactions occasionally hanging forever on multi-core chips
 
 ### Added
 - `QueueSet2`, `QueueSet3`, `QueueSet4` for waiting on multiple heterogeneous queues

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -2110,11 +2110,9 @@ async fn spi_transmit_async(
             }
         };
 
-        let pop = |queue: &mut Queue| {
+        let pop = |queue: &mut Queue, delay: TickType_t| {
             let mut rtrans = ptr::null_mut();
-            match esp!(unsafe {
-                spi_device_get_trans_result(handle, &mut rtrans, delay::NON_BLOCK)
-            }) {
+            match esp!(unsafe { spi_device_get_trans_result(handle, &mut rtrans, delay) }) {
                 Err(e) if e.code() == ESP_ERR_TIMEOUT => return Ok(false),
                 Err(e) => Err(e)?,
                 Ok(()) => (),
@@ -2130,14 +2128,23 @@ async fn spi_transmit_async(
             Ok(true)
         };
 
-        for transaction in transactions {
-            while queue.len() == queue_size {
-                if pop(queue)? {
-                    break;
-                }
+        // NOTE: after a successful `wait().await`, the front transaction result MUST be
+        // fetched with a blocking `pop`: the SPI ISR invokes the post-transaction callback
+        // (which fires the notification we just awaited) *before* it posts the result to
+        // the driver return queue (see `spi_intr` in ESP-IDF's `spi_master.c`:
+        // `spi_post_trans` runs before `xQueueSendFromISR`). On multi-core chips the
+        // awoken task can thus observe the notification before the result is visible. As
+        // the wait consumed the notification, going back to a non-blocking `pop` + `wait`
+        // would hang forever. The blocking fetch is safe: the ISR posts the result right
+        // after the callback.
 
-                // If the queue is full, we wait for the first transaction in the queue
-                queue.front_mut().unwrap().1.wait().await;
+        for transaction in transactions {
+            // If the queue is full, we wait for the first transaction in the queue
+            while queue.len() == queue_size {
+                if !pop(queue, delay::NON_BLOCK)? {
+                    queue.front_mut().unwrap().1.wait().await;
+                    pop(queue, delay::BLOCK)?;
+                }
             }
 
             // Write transaction to a stable memory location
@@ -2145,8 +2152,9 @@ async fn spi_transmit_async(
         }
 
         while !queue.is_empty() {
-            if !pop(queue)? {
+            if !pop(queue, delay::NON_BLOCK)? {
                 queue.front_mut().unwrap().1.wait().await;
+                pop(queue, delay::BLOCK)?;
             }
         }
 


### PR DESCRIPTION
### Submission Checklist 📝
- [x] ~I have updated existing examples or added new ones~ (not applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
The SPI ISR invokes the post-transaction callback (which fires the completion notification) *before* it posts the result to the driver return queue (see `spi_intr` in ESP-IDF's `spi_master.c`).

On multi-core chips the awoken task can thus poll the return queue before the result is visible, and since the wait consumed the notification, going back to waiting hangs forever.
    
Fix by fetching the result with a blocking pop after a successful wait: the ISR posts the result right after the callback, so it is guaranteed to arrive momentarily.

#### Testing
Was easily reproducible on ESP32 with a steady 45 transactions/s load talking to a BME280 sensor (using [this driver](https://github.com/VersBinarii/bme280-rs) latest master)
 - without the fix a hang occurred within 10 seconds
 - with the fix I never observed a hang