### PR TITLE
feat(i2s): add ClockSource::Xtal and default to it on ESP32-P4

### DIFF
--- a/src/i2s.rs
+++ b/src/i2s.rs
@@ -118,10 +118,24 @@ pub mod config {
     /// I2S clock source.
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
     pub enum ClockSource {
-        /// Use PLL_F160M as the source clock
+        /// Use PLL_F160M as the source clock.
+        ///
+        /// Not the default on the ESP32-P4: that chip's `i2s_ll_get_clk_src` only accepts
+        /// `PLL_F160M` when the build targets hardware revision v3 or later
+        /// (`CHIP_SUPPORT_MIN_REV >= 300`). Selecting it on an earlier revision trips
+        /// `HAL_ASSERT(false && "unsupported clock source")` and aborts while the channel is
+        /// being initialised, so P4 defaults to [`ClockSource::Xtal`] instead.
         #[cfg(not(any(esp32h2, esp32c2)))]
-        #[default]
+        #[cfg_attr(not(esp32p4), default)]
         Pll160M,
+
+        /// Use XTAL as the source clock.
+        ///
+        /// Always available on the ESP32-P4, at any hardware revision, which is why it is the
+        /// default there.
+        #[cfg(esp32p4)]
+        #[default]
+        Xtal,
 
         /// Use PLL_F60M as the source clock
         #[cfg(esp32c2)]
@@ -156,6 +170,11 @@ pub mod config {
                 #[cfg(esp32h2)]
                 Self::Pll64M => core::convert::TryInto::try_into(
                     esp_idf_sys::soc_module_clk_t_SOC_MOD_CLK_PLL_F64M,
+                )
+                .unwrap(),
+                #[cfg(esp32p4)]
+                Self::Xtal => core::convert::TryInto::try_into(
+                    esp_idf_sys::soc_module_clk_t_SOC_MOD_CLK_XTAL,
                 )
                 .unwrap(),
                 #[cfg(any(esp32, esp32s2))]


### PR DESCRIPTION
## Problem

On the ESP32-P4, `ClockSource` currently offers only `Pll160M` (it is also the `#[default]`).
But the P4 accepts `PLL_F160M` **only from hardware revision v3**. From
`components/hal/esp32p4/include/hal/i2s_ll.h`:

```c
case I2S_CLK_SRC_DEFAULT:
#if HAL_CONFIG(CHIP_SUPPORT_MIN_REV) >= 300
    return 3;
// Only support PLL_160M on P4 ver3 and later
case I2S_CLK_SRC_PLL_160M:
    return 3;
#else
    return 0;
#endif
default:
    HAL_ASSERT(false && "unsupported clock source");
```

So on a pre-v3 P4 there is no expressible valid value at all: any `I2sDriver` creation lands in
the `default:` arm and aborts. Concretely, on a rev-v1.0 module:

```
assert failed: i2s_ll_get_clk_src .../hal/esp32p4/include/hal/i2s_ll.h:435 (false && "unsupported clock source")
Core 0 register dump: ...
```

The chip then boot-loops. `StdClkConfig::from_sample_rate_hz()` reaches this by default, so I2S
is simply unusable on that silicon today.

## Change

Add `ClockSource::Xtal` and make it the default on `esp32p4`. XTAL is accepted at every P4
revision (`i2s_ll_get_clk_src` maps it to 0 unconditionally). `Pll160M` remains selectable for
rev-v3+ builds.

The diff is confined to `#[cfg(esp32p4)]` and `#[cfg_attr(not(esp32p4), default)]`, so every
other target compiles identical code.

## Testing

Verified on an ESP32-P4 rev v1.0 module (ESP32-P4NRW32) with ESP-IDF v5.5.3, driving an ES8311
DAC + ES7210 ADC over a shared bidirectional I2S bus at 24 kHz / 16-bit:

- before: boot-loop at `I2sDriver::new_std_bidir`
- after: `i2s bidir up (24k/16-bit)`, and a full-duplex voice session runs with mic capture and
  speaker playback both working, no dropped frames

Also rebuilt an `xtensa-esp32s3-espidf` firmware from the same tree to confirm the S3 path is
unaffected.

## Notes

- The P4 also supports `I2S_CLK_SRC_APLL`, which would suit exact audio rates better than XTAL's
  fractional division. I left it out to keep this minimal, but I am happy to add it if you would
  prefer both in one go.
- Naming: I used `Xtal` to match `I2S_CLK_SRC_XTAL`. If you would rather expose
  `I2S_CLK_SRC_DEFAULT` (which resolves to XTAL below rev v3 and PLL_160M at/above it), say the
  word and I will switch it.
