### PR TITLE
fix: support sdmmc_host_t field also in ESP-IDF v5.5.5 (backported from ESP-IDF v6.0.1+)

### DIFF
--- a/src/sd.rs
+++ b/src/sd.rs
@@ -327,7 +327,10 @@ mod sdcard {
                     all(esp_idf_version_major = "5", esp_idf_version_minor = "3"),
                 )))] // For ESP-IDF v5.4 and later
                 is_slot_set_to_uhs1: None,
-                #[cfg(esp_idf_version_at_least_6_0_1)]
+                #[cfg(any(
+                    esp_idf_version_at_least_6_0_1,
+                    esp_idf_version_patch_at_least_5_5_5,
+                ))]
                 unaligned_multi_block_rw_max_chunk_size: 0,
             };
 
@@ -433,7 +436,10 @@ mod sdcard {
                     all(esp_idf_version_major = "5", esp_idf_version_minor = "3"),
                 )))] // For ESP-IDF v5.4 and later
                 is_slot_set_to_uhs1: None,
-                #[cfg(esp_idf_version_at_least_6_0_1)]
+                #[cfg(any(
+                    esp_idf_version_at_least_6_0_1,
+                    esp_idf_version_patch_at_least_5_5_5,
+                ))]
                 unaligned_multi_block_rw_max_chunk_size: 0,
             };
 


### PR DESCRIPTION
Just a minor change, see also #586:

ESP-IDF v6.0.1 had added unaligned_multi_block_rw_max_chunk_size to sdmmc_host_t.
This addition has been back-ported to v5.5.5 as well (https://github.com/espressif/esp-idf/blob/v5.5.5/components/sdmmc/include/sd_protocol_types.h#L253). This pull requests modifies the gated field initialiser, so the field gets initialized also in ESP-IDF v5.5.5. 
 
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [X] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [ ] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [X] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-hal/blob/main/esp-idf-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Please provide a clear and concise description of your changes, including the motivation behind these changes. The context is crucial for the reviewers.

#### Testing
Describe how you tested your changes.